### PR TITLE
remove categorical types from BTB

### DIFF
--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -4,19 +4,11 @@ from collections import namedtuple
 class ParamTypes(object):
 	INT = "int"
 	INT_EXP = "int_exp"
-	INT_CAT = "int_cat"
 	FLOAT = "float"
 	FLOAT_EXP = "float_exp"
-	FLOAT_CAT = "float_cat"
-	STRING = "string"
-	BOOL = "bool"
 
 # List of exponential hyperparameter types
 EXP_TYPES = [ParamTypes.INT_EXP, ParamTypes.FLOAT_EXP]
-
-# List of categorical hyperparameter types
-CAT_TYPES = [ParamTypes.INT_CAT, ParamTypes.FLOAT_CAT, ParamTypes.STRING,
-             ParamTypes.BOOL]
 
 
 # our HyperParameter object
@@ -26,23 +18,13 @@ class HyperParameter(object):
             if val is None:
                 # the value None is allowed for every parameter type
                 continue
-            if typ in [ParamTypes.INT, ParamTypes.INT_EXP,
-                       ParamTypes.INT_CAT]:
+            if typ in [ParamTypes.INT, ParamTypes.INT_EXP]:
                 rang[i] = int(val)
-            elif typ in [ParamTypes.FLOAT, ParamTypes.FLOAT_EXP,
-                         ParamTypes.FLOAT_CAT]:
+            elif typ in [ParamTypes.FLOAT, ParamTypes.FLOAT_EXP]:
                 rang[i] = float(val)
-            elif typ == ParamTypes.STRING:
-                rang[i] = str(newstr(val))
-            elif typ == ParamTypes.BOOL:
-                rang[i] = bool(val)
         self.type = typ
         self.range = rang
 
     @property
     def is_exponential(self):
         return self.type in EXP_TYPES
-
-    @property
-    def is_categorical(self):
-        return self.type in CAT_TYPES


### PR DESCRIPTION
This goes along with [#60](https://github.com/HDI-Project/ATM/pull/60) over at atm. Categorical types were never relevant to BTB on its own, so they're being removed.