### PR TITLE
Updated version number in setup.py for submitting to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.1',
+    version='0.1.0',
 
     description='A framework for Bayesian hyperparameter selection and tuning',
 
@@ -63,4 +63,3 @@ setup(
     # TODO
     install_requires=['future'],
 )
-


### PR DESCRIPTION
To allow users to instal v0.1.0, the package metadata in setup.py must list the version number as 0.1.0 and must be resubmitted to PyPI.