### PR TITLE
inverse transform for categorical hyperparameter returns single item

### DIFF
--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -146,7 +146,8 @@ class CatHyperParameter(HyperParameter):
                     min_diff = diff[i]
                     max_key = keys[i]
             return random.choice(np.vectorize(inv_map.get)(max_key))
-        return np.vectorize(invert)(inv_map, x)
+        inv_trans = np.vectorize(invert)(inv_map, x)
+        return inv_trans.item() if np.ndim(inv_trans) == 0 else inv_trans
 
 
 class IntCatHyperParameter(CatHyperParameter):


### PR DESCRIPTION
For inverse transforming for a categorical hyperparameter, the function used to return an array regardless of the type. Now it returns a single item if the input to inverse trasnform is a single item, and array if it is an array.

Before:
![before](https://user-images.githubusercontent.com/11840728/38386756-bc8b4c06-38e3-11e8-8973-57fdb6de4994.png)


After:
![after](https://user-images.githubusercontent.com/11840728/38386755-bc64af7e-38e3-11e8-9ece-5900c8c2ecc2.png)
