### PR TITLE
Add copy support

### DIFF
--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -57,7 +57,7 @@ class HyperParameter(object):
 
 class IntHyperParameter(HyperParameter):
     def __init__(self, typ, rang):
-        HyperParameter.__init__(self, rang, int)
+        super().__init__(rang, int)
 
     @property
     def is_integer(self):
@@ -69,12 +69,12 @@ class IntHyperParameter(HyperParameter):
 
 class FloatHyperParameter(HyperParameter):
     def __init__(self, typ, rang):
-        HyperParameter.__init__(self, rang, float)
+        super().__init__(rang, float)
 
 
 class FloatExpHyperParameter(HyperParameter):
     def __init__(self, typ, rang):
-        HyperParameter.__init__(self, rang, lambda x: math.log10(float(x)))
+        super().__init__(rang, lambda x: math.log10(float(x)))
 
     def fit_transform(self, x, y):
         x = x.astype(float)
@@ -86,6 +86,7 @@ class FloatExpHyperParameter(HyperParameter):
 
 class IntExpHyperParameter(FloatExpHyperParameter):
     def __init__(self, typ, rang):
+        # can't use super() because we need to provide a cast explicitly
         HyperParameter.__init__(self, rang, lambda x: math.log10(int(x)))
 
     @property
@@ -93,14 +94,14 @@ class IntExpHyperParameter(FloatExpHyperParameter):
         return True
 
     def inverse_transform(self, x):
-        return FloatExpHyperParameter.inverse_transform(self, x).astype(int)
+        return super().inverse_transform(x).astype(int)
 
 
 class CatHyperParameter(HyperParameter):
     def __init__(self, rang, cast):
         self.cat_transform = {cast(each): 0 for each in rang}
         # this is a dummy range until the transformer is fit
-        HyperParameter.__init__(self, [0.0, 1.0], float)
+        super().__init__([0.0, 1.0], float)
 
     def fit_transform(self, x, y):
         self.cat_transform = {each: (0, 0) for each in self.cat_transform}
@@ -151,22 +152,22 @@ class CatHyperParameter(HyperParameter):
 
 class IntCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        CatHyperParameter.__init__(self, rang, int)
+        super().__init__(rang, int)
 
 
 class FloatCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        CatHyperParameter.__init__(self, rang, float)
+        super().__init__(rang, float)
 
 
 class StringCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        CatHyperParameter.__init__(self, rang, lambda x: str(newstr(x)))
+        super().__init__(rang, lambda x: str(newstr(x)))
 
 
 class BoolCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        CatHyperParameter.__init__(self, rang, bool)
+        super().__init__(rang, bool)
 
 
 CLASS_GENERATOR = {

--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -1,3 +1,5 @@
+import copy
+
 from builtins import object, str as newstr
 from collections import namedtuple, defaultdict
 import math
@@ -33,6 +35,20 @@ class HyperParameter(object):
                 continue
             rang[i] = cast(val)
         self.range = rang
+
+    def __copy__(self):
+        cls = self.__class__
+        result = cls.__new__(cls, INVERSE_CLASS_GENERATOR[cls], self.range)
+        result.__dict__.update(self.__dict__)
+        return result
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls, INVERSE_CLASS_GENERATOR[cls], self.range)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            setattr(result, k, copy.deepcopy(v, memo))
+        return result
 
     @property
     def is_integer(self):
@@ -180,3 +196,5 @@ CLASS_GENERATOR = {
     ParamTypes.STRING: StringCatHyperParameter,
     ParamTypes.BOOL: BoolCatHyperParameter,
 }
+
+INVERSE_CLASS_GENERATOR = {CLASS_GENERATOR[k]: k for k in CLASS_GENERATOR}

--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -57,7 +57,7 @@ class HyperParameter(object):
 
 class IntHyperParameter(HyperParameter):
     def __init__(self, typ, rang):
-        super().__init__(rang, int)
+        super(IntHyperParameter, self).__init__(rang, int)
 
     @property
     def is_integer(self):
@@ -69,12 +69,12 @@ class IntHyperParameter(HyperParameter):
 
 class FloatHyperParameter(HyperParameter):
     def __init__(self, typ, rang):
-        super().__init__(rang, float)
+        super(FloatHyperParameter, self).__init__(rang, float)
 
 
 class FloatExpHyperParameter(HyperParameter):
     def __init__(self, typ, rang):
-        super().__init__(rang, lambda x: math.log10(float(x)))
+        super(FloatExpHyperParameter, self).__init__(rang, lambda x: math.log10(float(x)))
 
     def fit_transform(self, x, y):
         x = x.astype(float)
@@ -94,14 +94,14 @@ class IntExpHyperParameter(FloatExpHyperParameter):
         return True
 
     def inverse_transform(self, x):
-        return super().inverse_transform(x).astype(int)
+        return super(IntExpHyperParameter, self).inverse_transform(x).astype(int)
 
 
 class CatHyperParameter(HyperParameter):
     def __init__(self, rang, cast):
         self.cat_transform = {cast(each): 0 for each in rang}
         # this is a dummy range until the transformer is fit
-        super().__init__([0.0, 1.0], float)
+        super(CatHyperParameter, self).__init__([0.0, 1.0], float)
 
     def fit_transform(self, x, y):
         self.cat_transform = {each: (0, 0) for each in self.cat_transform}
@@ -152,22 +152,22 @@ class CatHyperParameter(HyperParameter):
 
 class IntCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        super().__init__(rang, int)
+        super(IntCatHyperParameter, self).__init__(rang, int)
 
 
 class FloatCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        super().__init__(rang, float)
+        super(FloatCatHyperParameter, self).__init__(rang, float)
 
 
 class StringCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        super().__init__(rang, lambda x: str(newstr(x)))
+        super(StringCatHyperParameter, self).__init__(rang, lambda x: str(newstr(x)))
 
 
 class BoolCatHyperParameter(CatHyperParameter):
     def __init__(self, typ, rang):
-        super().__init__(rang, bool)
+        super(BoolCatHyperParameter, self).__init__(rang, bool)
 
 
 CLASS_GENERATOR = {

--- a/btb/tests/test_hyperparameter.py
+++ b/btb/tests/test_hyperparameter.py
@@ -1,3 +1,5 @@
+import copy
+
 from btb import HyperParameter, ParamTypes
 import numpy as np
 import numpy.testing
@@ -5,6 +7,17 @@ import unittest
 
 
 class TestHyperparameter(unittest.TestCase):
+    def setUp(self):
+        self.parameter_constructions = [
+            (ParamTypes.INT, [1,3]),
+            (ParamTypes.INT_EXP, [10, 10000]),
+            (ParamTypes.FLOAT, [1.5, 3.2]),
+            (ParamTypes.FLOAT_EXP, [0.001, 100]),
+            (ParamTypes.FLOAT_CAT, [0.1, 0.6, 0.5]),
+            (ParamTypes.BOOL, [True, False]),
+            (ParamTypes.STRING, ['a', 'b', 'c']),
+        ]
+
     def test_int(self):
         hyp = HyperParameter(ParamTypes.INT, [1, 3])
         self.assertEqual(hyp.range, [1, 3])
@@ -110,3 +123,25 @@ class TestHyperparameter(unittest.TestCase):
         )
         inverse_transform = hyp.inverse_transform([3])
         numpy.testing.assert_array_equal(inverse_transform, np.array(['c']))
+
+    def test_copy(self):
+        for typ, rang in self.parameter_constructions:
+            hyp = HyperParameter(typ, rang)
+            hyp_copy = copy.copy(hyp)
+            self.assertIsNot(hyp, hyp_copy)
+            self.assertIs(type(hyp), type(hyp_copy))
+            self.assertEqual(hyp.range, hyp_copy.range)
+
+            # shallow copy should just have copied references
+            self.assertIs(hyp.range, hyp_copy.range)
+
+    def test_deepcopy(self):
+        for typ, rang in self.parameter_constructions:
+            hyp = HyperParameter(typ, rang)
+            hyp_copy = copy.deepcopy(hyp)
+            self.assertIsNot(hyp, hyp_copy)
+            self.assertIs(type(hyp), type(hyp_copy))
+            self.assertEqual(hyp.range, hyp_copy.range)
+
+            # deep copy should have new attributes
+            self.assertIsNot(hyp.range, hyp_copy.range)


### PR DESCRIPTION
Add support for `copy.copy` and `copy.deepcopy` on instances of `HyperParameter`.

This may be helpful in general, but it is specifically helpful in the case where a btb Tuner is to be incorporated within an sklearn estimator. In that case, `sklearn.base.clone` would be called frequently on the estimator, and copy support is needed all the way down. (Indeed, this is the exact situation I'm having.)

Previous to this PR, copy fails as follows:
```
In [5]: hp = btb.HyperParameter(btb.ParamTypes.INT, [0, 2])

In [6]: import copy

In [7]: copy.copy(hp)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-7-1e8282bccb37> in <module>()
----> 1 copy.copy(hp)

/usr/local/anaconda3/lib/python3.6/copy.py in copy(x)
    104     if isinstance(rv, str):
    105         return x
--> 106     return _reconstruct(x, None, *rv)
    107 
    108 

/usr/local/anaconda3/lib/python3.6/copy.py in _reconstruct(x, memo, func, args, state, listiter, dictiter, deepcopy)
    272     if deep and args:
    273         args = (deepcopy(arg, memo) for arg in args)
--> 274     y = func(*args)
    275     if deep:
    276         memo[id(x)] = y

/usr/local/anaconda3/lib/python3.6/copyreg.py in __newobj__(cls, *args)
     86 
     87 def __newobj__(cls, *args):
---> 88     return cls.__new__(cls, *args)
     89 
     90 def __newobj_ex__(cls, args, kwargs):

TypeError: __new__() missing 2 required positional arguments: 'typ' and 'rang'
```