### PR TITLE
Refactored recommender class and added uniform reccomender

### DIFF
--- a/btb/recommendation/__init__.py
+++ b/btb/recommendation/__init__.py
@@ -1,3 +1,11 @@
-from btb.recommendation.recommender import Recommender
+from btb.recommendation.matrix_factorization import (
+    MFRecommender
+)
+from btb.recommendation.recommender import BaseRecommender
+from btb.recommendation.uniform import UniformRecommender
 
-__all__ = ('Recommender',)
+__all__ = (
+    'BaseRecommender',
+    'MFRecommender',
+    'UniformRecommender'
+)

--- a/btb/recommendation/__init__.py
+++ b/btb/recommendation/__init__.py
@@ -1,7 +1,5 @@
+from btb.recommendation.matrix_factorization import MFRecommender
 from btb.recommendation.recommender import BaseRecommender
-from btb.recommendation.matrix_factorization import (
-    MFRecommender
-)
 from btb.recommendation.uniform import UniformRecommender
 
 __all__ = (

--- a/btb/recommendation/__init__.py
+++ b/btb/recommendation/__init__.py
@@ -1,7 +1,7 @@
+from btb.recommendation.recommender import BaseRecommender
 from btb.recommendation.matrix_factorization import (
     MFRecommender
 )
-from btb.recommendation.recommender import BaseRecommender
 from btb.recommendation.uniform import UniformRecommender
 
 __all__ = (

--- a/btb/recommendation/matrix_factorization.py
+++ b/btb/recommendation/matrix_factorization.py
@@ -35,7 +35,7 @@ class MFRecommender(BaseRecommender):
             new dataset D. Identified in fit.
     """
 
-    def __init__(self, dpp_matrix, n_components=100, **kwargs):
+    def __init__(self, dpp_matrix, n_components=100):
         """
         Args:
             dpp_matrix: np.array shape = (num_datasets, num_pipelines) Sparse
@@ -49,10 +49,7 @@ class MFRecommender(BaseRecommender):
         """
         self.dpp_matrix = dpp_matrix
         self.n_components = n_components
-        self.mf_model = NMF(
-            n_components=n_components,
-            init='nndsvd',
-        )
+        self.mf_model = NMF(n_components=n_components, init='nndsvd')
         dpp_decomposed = self.mf_model.fit_transform(dpp_matrix)
         self.dpp_ranked = np.empty(dpp_decomposed.shape)
         for i in range(dpp_decomposed.shape[0]):

--- a/btb/recommendation/matrix_factorization.py
+++ b/btb/recommendation/matrix_factorization.py
@@ -1,0 +1,117 @@
+import logging
+
+import numpy as np
+import scipy.stats as stats
+from sklearn.decomposition import NMF
+
+from btb.recommendation.recommender import BaseRecommender
+
+LOGGER = logging.getLogger('btb')
+
+
+class MFRecommender(BaseRecommender):
+    """
+    Recommender for recomending pipelines to try on a new dataset D based
+    on performances of datasets on the different pipeline options. Recommends
+    pipelines that would maximize the score value. Uses Matrix Factorization
+    to determine which pipeline to recommend.
+
+    Attributes:
+        dpp_matrix: (2D np.array) Dataset performance pipeline matrix. Num
+            datasets by num pipelines matrix where each row i corresponds to a
+            dataset and each collumn j corresponds to a pipeline. The
+            dpp_marix[i,j] is the score of pipeline j on dataset i or 0 if
+            pipeline j has not beentried on dataset i.
+        n_components: (int) The number of components (columsn) to keep after
+            Matrix Factorxation.
+        mf_model: Matrix Factorization model that reduces dimensionailty from
+            num pipelines space to n_components space.
+        dpp_ranked: (2D np.array) Matrix of rankings for each row of dpp_matrix
+            after matrix facorization has been applied.
+        dpp_vector: (1D np.array) Vector representing pipeline performances on
+            a new dataset D.
+        matching_dataset: (1D np.array) Row from dpp_matrix representing
+            pipeline performances for the dataset that most closely matches the
+            new dataset D. Identified in fit.
+    """
+
+    def __init__(self, dpp_matrix, n_components=100, **kwargs):
+        """
+        Args:
+            dpp_matrix: np.array shape = (num_datasets, num_pipelines) Sparse
+                dataset performance matrix pertaining to pipeline
+                scores on different dataset. Each row i coresponds to a dataset
+                and each column j corresponds to a pipeline. dpp_matrix[i,j]
+                corresponds to the score of the pipeline j on the dataset and
+                is 0 if the pipeline was not tried on the dataset
+            n_components: int. Corresponds to the number of features to keep
+                in matrix decomposition. Must be >= number of rows in matrix
+        """
+        self.dpp_matrix = dpp_matrix
+        self.n_components = n_components
+        self.mf_model = NMF(
+            n_components=n_components,
+            init='nndsvd',
+        )
+        dpp_decomposed = self.mf_model.fit_transform(dpp_matrix)
+        self.dpp_ranked = np.empty(dpp_decomposed.shape)
+        for i in range(dpp_decomposed.shape[0]):
+            rankings = stats.rankdata(
+                dpp_decomposed[i, :],
+                method='dense'
+            )
+            self.dpp_ranked[i, :] = rankings
+        self.dpp_vector = np.zeros(self.dpp_matrix.shape[1])
+        random_matching_index = np.random.randint(self.dpp_matrix.shape[0])
+        self.matching_dataset = self.dpp_matrix[random_matching_index, :]
+
+    def fit(self, dpp_vector):
+        """
+        Finds row of self.dpp_matrix most closely corresponds to X by means
+        of Kendall tau distance.
+        https://en.wikipedia.org/wiki/Kendall_tau_distance
+
+        Args:
+            dpp_vector: np.array shape = (self.n_components,)
+        """
+
+        # decompose X and generate the rankings of the elements in the
+        # decomposed matrix
+        dpp_vector_decomposed = self.mf_model.transform(dpp_vector)
+        dpp_vector_ranked = stats.rankdata(
+            dpp_vector_decomposed,
+            method='dense',
+        )
+
+        max_agreement_index = None
+        max_agreement = -1  # min value of Kendall Tau agremment
+        for i in range(self.dpp_ranked.shape[0]):
+            # calculate agreement between current row and X
+            agreement, _ = stats.kendalltau(
+                dpp_vector_ranked,
+                self.dpp_ranked[i, :],
+            )
+            if agreement > max_agreement:
+                max_agreement_index = i
+                max_agreement = agreement
+
+        if max_agreement_index is None:
+            max_agreement_index = np.random.randint(self.dpp_matrix.shape[0])
+        # store the row with the highest agreement for prediction
+        self.matching_dataset = self.dpp_matrix[max_agreement_index, :]
+
+    def predict(self, indicies):
+        """
+        Predicts the relative rankings of the pipelines on dpp_vector for
+        a series of pipelines represented by their indicies.
+
+        Args:
+            indicies: np.array of pipeline indicies, shape = (n_samples)
+
+        Returns:
+            y: np.array of predicted scores, shape = (n_samples)
+        """
+        matching_scores = np.array(
+            [self.matching_dataset[each] for each in indicies]
+        )
+        return stats.rankdata(matching_scores, method='dense')

--- a/btb/recommendation/recommender.py
+++ b/btb/recommendation/recommender.py
@@ -21,7 +21,7 @@ class BaseRecommender(object):
             a new dataset D.
     """
 
-    def __init__(self, dpp_matrix, **kwargs):
+    def __init__(self, dpp_matrix):
         """
         Args:
             dpp_matrix: np.array shape = (num_datasets, num_pipelines) Sparse

--- a/btb/recommendation/recommender.py
+++ b/btb/recommendation/recommender.py
@@ -1,17 +1,15 @@
 import logging
 
 import numpy as np
-import scipy.stats as stats
-from sklearn.decomposition import NMF
 
 logger = logging.getLogger('btb')
 
 
-class Recommender(object):
+class BaseRecommender(object):
     """
-    Basic Recommender for recomending pipelines to try on a new dataset D based
-    on performances of datasets on the different pipeline options. Recommends
-    pipelines that would maximize the score value.
+    Base Recommender class for recomending pipelines to try on a new dataset
+    D based on performances of datasets on the different pipeline options.
+    Recommends pipelines that would maximize the score value.
 
     Attributes:
         dpp_matrix: (2D np.array) Dataset performance pipeline matrix. Num
@@ -19,20 +17,11 @@ class Recommender(object):
             dataset and each collumn j corresponds to a pipeline. The
             dpp_marix[i,j] is the score of pipeline j on dataset i or 0 if
             pipeline j has not beentried on dataset i.
-        n_components: (int) The number of components (columsn) to keep after
-            Matrix Factorxation.
-        mf_model: Matrix Factorization model that reduces dimensionailty from
-            num pipelines space to n_components space.
-        dpp_ranked: (2D np.array) Matrix of rankings for each row of dpp_matrix
-            after matrix facorization has been applied.
         dpp_vector: (1D np.array) Vector representing pipeline performances on
             a new dataset D.
-        matching_dataset: (1D np.array) Row from dpp_matrix representing
-            pipeline performances for the dataset that most closely matches the
-            new dataset D. Identified in fit.
     """
 
-    def __init__(self, dpp_matrix, n_components=100, **kwargs):
+    def __init__(self, dpp_matrix, **kwargs):
         """
         Args:
             dpp_matrix: np.array shape = (num_datasets, num_pipelines) Sparse
@@ -41,61 +30,17 @@ class Recommender(object):
                 and each column j corresponds to a pipeline. dpp_matrix[i,j]
                 corresponds to the score of the pipeline j on the dataset and
                 is 0 if the pipeline was not tried on the dataset
-            n_components: int. Corresponds to the number of features to keep
-                in matrix decomposition. Must be >= number of rows in matrix
         """
         self.dpp_matrix = dpp_matrix
-        self.n_components = n_components
-        self.mf_model = NMF(
-            n_components=n_components,
-            init='nndsvd',
-        )
-        dpp_decomposed = self.mf_model.fit_transform(dpp_matrix)
-        self.dpp_ranked = np.empty(dpp_decomposed.shape)
-        for i in range(dpp_decomposed.shape[0]):
-            rankings = stats.rankdata(
-                dpp_decomposed[i, :],
-                method='dense'
-            )
-            self.dpp_ranked[i, :] = rankings
         self.dpp_vector = np.zeros(self.dpp_matrix.shape[1])
-        random_matching_index = np.random.randint(self.dpp_matrix.shape[0])
-        self.matching_dataset = self.dpp_matrix[random_matching_index, :]
 
     def fit(self, dpp_vector):
         """
-        Finds row of self.dpp_matrix most closely corresponds to X by means
-        of Kendall tau distance.
-        https://en.wikipedia.org/wiki/Kendall_tau_distance
-
+        Fits the Recommender model.
         Args:
             dpp_vector: np.array shape = (self.n_components,)
         """
-
-        # decompose X and generate the rankings of the elements in the
-        # decomposed matrix
-        dpp_vector_decomposed = self.mf_model.transform(dpp_vector)
-        dpp_vector_ranked = stats.rankdata(
-            dpp_vector_decomposed,
-            method='dense',
-        )
-
-        max_agreement_index = None
-        max_agreement = -1  # min value of Kendall Tau agremment
-        for i in range(self.dpp_ranked.shape[0]):
-            # calculate agreement between current row and X
-            agreement, p_value = stats.kendalltau(
-                dpp_vector_ranked,
-                self.dpp_ranked[i, :],
-            )
-            if agreement > max_agreement:
-                max_agreement_index = i
-                max_agreement = agreement
-
-        if max_agreement_index is None:
-            max_agreement_index = np.random.randint(self.dpp_matrix.shape[0])
-        # store the row with the highest agreement for prediction
-        self.matching_dataset = self.dpp_matrix[max_agreement_index, :]
+        self.dpp_vector = dpp_vector
 
     def predict(self, indicies):
         """
@@ -108,10 +53,10 @@ class Recommender(object):
         Returns:
             y: np.array of predicted scores, shape = (n_samples)
         """
-        matching_scores = np.array(
-            [self.matching_dataset[each] for each in indicies]
+        raise NotImplementedError(
+            'predict() needs to be implemented by a' +
+            'subclass of BaseRecommender'
         )
-        return stats.rankdata(matching_scores, method='dense')
 
     def _acquire(self, predictions):
         """

--- a/btb/recommendation/uniform.py
+++ b/btb/recommendation/uniform.py
@@ -1,0 +1,38 @@
+import logging
+
+import numpy as np
+
+from btb.recommendation.recommender import BaseRecommender
+
+LOGGER = logging.getLogger('btb')
+
+
+class UniformRecommender(BaseRecommender):
+    """
+    Uniform Recommender for recomending pipelines to try on a new dataset D
+    based on performances of datasets on the different pipeline options.
+    Recommends pipelines that would maximize the score value. Raondomly
+    ranks pipelines.
+
+    Attributes:
+        dpp_matrix: (2D np.array) Dataset performance pipeline matrix. Num
+            datasets by num pipelines matrix where each row i corresponds to a
+            dataset and each collumn j corresponds to a pipeline. The
+            dpp_marix[i,j] is the score of pipeline j on dataset i or 0 if
+            pipeline j has not beentried on dataset i.
+        dpp_vector: (1D np.array) Vector representing pipeline performances on
+            a new dataset D.
+    """
+
+    def predict(self, indicies):
+        """
+        Predicts the relative rankings of the pipelines on dpp_vector for
+        a series of pipelines represented by their indicies.
+
+        Args:
+            indicies: np.array of pipeline indicies, shape = (n_samples)
+
+        Returns:
+            y: np.array of predicted scores, shape = (n_samples)
+        """
+        return np.random.permutation(indicies.shape[0])

--- a/tests/btb/recommendation/test_matrix_factorization_recommender.py
+++ b/tests/btb/recommendation/test_matrix_factorization_recommender.py
@@ -56,13 +56,13 @@ class TestBaseRecommender(TestCase):
         dpp_vector = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         # Run
         recommender = MFRecommender(self.dpp_matrix, n_components)
-        for i in range(self.dpp_ranked.shape[0]):
-            nmf_mock().transform.return_value = self.dpp_ranked[i, :]
-            recommender.fit(dpp_vector)
-            np.testing.assert_array_equal(
-                recommender.matching_dataset,
-                self.dpp_matrix[i],
-            )
+        i = 0
+        nmf_mock().transform.return_value = self.dpp_ranked[i, :]
+        recommender.fit(dpp_vector)
+        np.testing.assert_array_equal(
+            recommender.matching_dataset,
+            self.dpp_matrix[i],
+        )
 
     def test_predict_one(self):
         # Run

--- a/tests/btb/recommendation/test_matrix_factorization_recommender.py
+++ b/tests/btb/recommendation/test_matrix_factorization_recommender.py
@@ -1,0 +1,125 @@
+from unittest import TestCase
+
+import numpy as np
+from mock import patch
+
+from btb.recommendation.matrix_factorization import MFRecommender
+
+
+class TestBaseRecommender(TestCase):
+    def setUp(self):
+        self.n_components = 3
+        self.dpp_decomposed = np.array([
+            [.0, .2, .4],
+            [.8, .6, .4],
+            [1.0, .8, 0.9],
+            [.6, 1.0, 0.8],
+        ])
+        self.dpp_ranked = np.array([
+            [1, 2, 3],
+            [3, 2, 1],
+            [3, 1, 2],
+            [1, 3, 2],
+        ])
+        # Set-up
+        self.dpp_matrix = np.array([
+            [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0],
+            [0, 4, 0, 6, 0, 4, 0, 2, 1, 0, 0, 2, 3, 1, 0, 0],
+            [1, 0, 1, 2, 0, 0, 6, 1, 0, 5, 1, 0, 0, 0, 0, 1],
+            [0, 2, 3, 0, 0, 0, 0, 0, 4, 1, 3, 2, 0, 0, 1, 4]
+        ])
+
+    @patch('btb.recommendation.matrix_factorization.np.random.randint')
+    @patch('btb.recommendation.matrix_factorization.NMF')
+    def test___init__(self, nmf_mock, randint_mock):
+        # set-up
+        index = 1
+        nmf_mock().fit_transform.return_value = self.dpp_ranked
+        randint_mock.return_value = index
+
+        # run
+        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+
+        # asserts
+        randint_mock.assert_called_once_with(4)  # 4 is self.dpp_matrix length
+        np.testing.assert_array_equal(
+            recommender.matching_dataset,
+            self.dpp_matrix[index, :],
+        )
+        np.testing.assert_array_equal(recommender.dpp_matrix, self.dpp_matrix)
+        np.testing.assert_array_equal(recommender.dpp_ranked, self.dpp_ranked)
+
+    @patch('btb.recommendation.matrix_factorization.NMF')
+    def test_fit(self, nmf_mock):
+        nmf_mock().fit_transform.return_value = self.dpp_ranked
+        n_components = 3
+        dpp_vector = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        # Run
+        recommender = MFRecommender(self.dpp_matrix, n_components)
+        for i in range(self.dpp_ranked.shape[0]):
+            nmf_mock().transform.return_value = self.dpp_ranked[i, :]
+            recommender.fit(dpp_vector)
+            np.testing.assert_array_equal(
+                recommender.matching_dataset,
+                self.dpp_matrix[i],
+            )
+
+    def test_predict_one(self):
+        # Run
+        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
+        recommender.matching_dataset = self.dpp_matrix[0]
+
+        indicies = [0]
+        predictions = recommender.predict(indicies)
+        expected = [1]
+        np.testing.assert_array_equal(predictions, expected)
+
+    def test_predict_all_matching(self):
+        # Run
+        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
+        recommender.matching_dataset = self.dpp_matrix[0]
+        indicies = [1, 2, 3, 4, 5]
+        predictions = recommender.predict(indicies)
+        expected = [1, 1, 1, 1, 1]
+        np.testing.assert_array_equal(predictions, expected)
+
+    def test_predict_multiple_rankings(self):
+        # Run
+        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
+        recommender.matching_dataset = self.dpp_matrix[0]
+        indicies = [0, 1, 14, 13]
+        predictions = recommender.predict(indicies)
+        expected = [2, 1, 3, 1]
+        np.testing.assert_array_equal(predictions, expected)
+
+    @patch('btb.recommendation.matrix_factorization.np.random.randint')
+    def test_propose_without_add(self, randint_mock):
+        index = 0
+        randint_mock.return_value = index
+        proposed = np.argmax(self.dpp_matrix[0])  # 14
+        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        np.testing.assert_array_equal(
+            recommender.matching_dataset,
+            self.dpp_matrix[index, :],
+        )
+        pipeline_index = recommender.propose()
+        randint_mock.assert_called_once_with(4)  # 4 is self.dpp_matrix length
+        assert pipeline_index == proposed
+
+    @patch('btb.recommendation.matrix_factorization.np.random.randint')
+    def test_propose_empty_add(self, randint_mock):
+        index = 0
+        randint_mock.return_value = index
+        proposed = np.argmax(self.dpp_matrix[0])  # 14
+        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        recommender.add({})
+        np.testing.assert_array_equal(
+            recommender.matching_dataset,
+            self.dpp_matrix[index, :],
+        )
+        pipeline_index = recommender.propose()
+        assert randint_mock.call_count == 2
+        assert pipeline_index == proposed

--- a/tests/btb/recommendation/test_recommender.py
+++ b/tests/btb/recommendation/test_recommender.py
@@ -3,24 +3,12 @@ from unittest import TestCase
 import numpy as np
 from mock import patch
 
-from btb.recommendation.recommender import Recommender
+from btb.recommendation.recommender import BaseRecommender
 
 
 class TestBaseRecommender(TestCase):
     def setUp(self):
         self.n_components = 3
-        self.dpp_decomposed = np.array([
-            [.0, .2, .4],
-            [.8, .6, .4],
-            [1.0, .8, 0.9],
-            [.6, 1.0, 0.8],
-        ])
-        self.dpp_ranked = np.array([
-            [1, 2, 3],
-            [3, 2, 1],
-            [3, 1, 2],
-            [1, 3, 2],
-        ])
         # Set-up
         self.dpp_matrix = np.array([
             [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0],
@@ -29,43 +17,25 @@ class TestBaseRecommender(TestCase):
             [0, 2, 3, 0, 0, 0, 0, 0, 4, 1, 3, 2, 0, 0, 1, 4]
         ])
 
-    @patch('btb.recommendation.recommender.np.random.randint')
-    @patch('btb.recommendation.recommender.NMF')
-    def test___init__(self, nmf_mock, randint_mock):
-        # set-up
-        index = 1
-        nmf_mock().fit_transform.return_value = self.dpp_ranked
-        randint_mock.return_value = index
-
-        # run
-        recommender = Recommender(self.dpp_matrix, self.n_components)
-
-        # asserts
-        randint_mock.assert_called_once_with(4)  # 4 is self.dpp_matrix length
-        np.testing.assert_array_equal(
-            recommender.matching_dataset,
-            self.dpp_matrix[index, :],
-        )
+    def test___init__(self):
+        # Run
+        recommender = BaseRecommender(self.dpp_matrix)
         np.testing.assert_array_equal(recommender.dpp_matrix, self.dpp_matrix)
-        np.testing.assert_array_equal(recommender.dpp_ranked, self.dpp_ranked)
+        # assert dpp_vector has same number of entries as pipelines
+        assert recommender.dpp_vector.shape[0] == self.dpp_matrix.shape[1]
 
-    @patch('btb.recommendation.recommender.NMF')
-    def test_fit(self, nmf_mock):
-        nmf_mock().fit_transform.return_value = self.dpp_ranked
-        n_components = 3
+    def test_fit(self):
         X = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         # Run
-        recommender = Recommender(self.dpp_matrix, n_components)
-        for i in range(self.dpp_ranked.shape[0]):
-            nmf_mock().transform.return_value = self.dpp_ranked[i, :]
-            recommender.fit(X)
-            np.testing.assert_array_equal(
-                recommender.matching_dataset,
-                self.dpp_matrix[i],
-            )
+        recommender = BaseRecommender(self.dpp_matrix)
+        recommender.fit(X)
+        np.testing.assert_array_equal(
+            X,
+            recommender.dpp_vector,
+        )
 
     def test__get_candidates_all(self):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         X = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         recommender.dpp_vector = X
         candidates = recommender._get_candidates()
@@ -78,7 +48,7 @@ class TestBaseRecommender(TestCase):
         )
 
     def test__get_candidates_some(self):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         X = np.array([0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0])
         recommender.dpp_vector = X
         expected = np.array([0, 1, 2, 4, 6, 8, 10, 11, 12, 14, 15])
@@ -89,7 +59,7 @@ class TestBaseRecommender(TestCase):
         )
 
     def test__get_candidates_none(self):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         X = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
         recommender.dpp_vector = X
         candidates = recommender._get_candidates()
@@ -97,61 +67,36 @@ class TestBaseRecommender(TestCase):
         self.assertEqual(expected, candidates)
 
     def test__acquire_last(self):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         predictions = np.array([1, 3, 5, 7])
         acquired = recommender._acquire(predictions)
         expected = 3
         self.assertEqual(acquired, expected)
 
     def test__acquire_middle(self):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         predictions = np.array([9, 10, 5, 7])
         acquired = recommender._acquire(predictions)
         expected = 1
         self.assertEqual(acquired, expected)
 
     def test__acquire_multiple(self):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         predictions = np.array([1, 9, 9, 7])
         acquired = recommender._acquire(predictions)
         expected_1 = 2
         expected_2 = 1
         self.assertTrue(acquired == expected_1 or acquired == expected_2)
 
-    def test_predict_one(self):
+    def test_predict(self):
         # Run
-        recommender = Recommender(self.dpp_matrix, self.n_components)
-        # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
-        recommender.matching_dataset = self.dpp_matrix[0]
-
+        recommender = BaseRecommender(self.dpp_matrix)
         indicies = [0]
-        predictions = recommender.predict(indicies)
-        expected = [1]
-        np.testing.assert_array_equal(predictions, expected)
+        self.assertRaises(NotImplementedError, recommender.predict, indicies)
 
-    def test_predict_all_matching(self):
-        # Run
-        recommender = Recommender(self.dpp_matrix, self.n_components)
-        # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
-        recommender.matching_dataset = self.dpp_matrix[0]
-        indicies = [1, 2, 3, 4, 5]
-        predictions = recommender.predict(indicies)
-        expected = [1, 1, 1, 1, 1]
-        np.testing.assert_array_equal(predictions, expected)
-
-    def test_predict_multiple_rankings(self):
-        # Run
-        recommender = Recommender(self.dpp_matrix, self.n_components)
-        # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
-        recommender.matching_dataset = self.dpp_matrix[0]
-        indicies = [0, 1, 14, 13]
-        predictions = recommender.predict(indicies)
-        expected = [2, 1, 3, 1]
-        np.testing.assert_array_equal(predictions, expected)
-
-    @patch('btb.recommendation.recommender.Recommender.fit')
+    @patch('btb.recommendation.recommender.BaseRecommender.fit')
     def test_add_none(self, fit_mock):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         recommender.add({})
         expected_x = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         np.testing.assert_array_equal(recommender.dpp_vector, expected_x)
@@ -161,9 +106,9 @@ class TestBaseRecommender(TestCase):
         )
         fit_mock.assert_called_once()
 
-    @patch('btb.recommendation.recommender.Recommender.fit')
+    @patch('btb.recommendation.recommender.BaseRecommender.fit')
     def test_add_once(self, fit_mock):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         recommender.add({1: 2, 3: 4, 5: 1})
         expected_x_1 = np.array(
             [0, 2, 0, 4, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -175,9 +120,9 @@ class TestBaseRecommender(TestCase):
         )
         fit_mock.assert_called_once()
 
-    @patch('btb.recommendation.recommender.Recommender.fit')
+    @patch('btb.recommendation.recommender.BaseRecommender.fit')
     def test_add_twice(self, fit_mock):
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
         recommender.add({1: 2, 3: 4, 5: 1})
         expected_x_1 = np.array(
             [0, 2, 0, 4, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -198,11 +143,10 @@ class TestBaseRecommender(TestCase):
         )
         self.assertEqual(fit_mock.call_count, 2)
 
-    @patch('btb.recommendation.recommender.Recommender._get_candidates')
-    @patch('btb.recommendation.recommender.Recommender.predict')
-    def test_propose_done(self, predict_mock, get_candidates_mock):
+    @patch('btb.recommendation.recommender.BaseRecommender._get_candidates')
+    def test_propose_done(self, get_candidates_mock):
         # Set-up
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
 
         get_candidates_mock.return_value = None
 
@@ -213,12 +157,12 @@ class TestBaseRecommender(TestCase):
         expected_params = None
         assert params == expected_params
 
-    @patch('btb.recommendation.recommender.Recommender._get_candidates')
-    @patch('btb.recommendation.recommender.Recommender.predict')
+    @patch('btb.recommendation.recommender.BaseRecommender._get_candidates')
+    @patch('btb.recommendation.recommender.BaseRecommender.predict')
     def test_propose_once(self, predict_mock, get_candidates_mock):
         """n == 1"""
         # Set-up
-        recommender = Recommender(self.dpp_matrix, self.n_components)
+        recommender = BaseRecommender(self.dpp_matrix)
 
         get_candidates_mock.return_value = [1, 3, 7, 8]
 
@@ -230,32 +174,3 @@ class TestBaseRecommender(TestCase):
         # Assert
         expected_pipeline_index = 3
         assert pipeline_index == expected_pipeline_index
-
-    @patch('btb.recommendation.recommender.np.random.randint')
-    def test_propose_without_add(self, randint_mock):
-        index = 0
-        randint_mock.return_value = index
-        proposed = np.argmax(self.dpp_matrix[0])  # 14
-        recommender = Recommender(self.dpp_matrix, self.n_components)
-        np.testing.assert_array_equal(
-            recommender.matching_dataset,
-            self.dpp_matrix[index, :],
-        )
-        pipeline_index = recommender.propose()
-        randint_mock.assert_called_once_with(4)  # 4 is self.dpp_matrix length
-        assert pipeline_index == proposed
-
-    @patch('btb.recommendation.recommender.np.random.randint')
-    def test_propose_empty_add(self, randint_mock):
-        index = 0
-        randint_mock.return_value = index
-        proposed = np.argmax(self.dpp_matrix[0])  # 14
-        recommender = Recommender(self.dpp_matrix, self.n_components)
-        recommender.add({})
-        np.testing.assert_array_equal(
-            recommender.matching_dataset,
-            self.dpp_matrix[index, :],
-        )
-        pipeline_index = recommender.propose()
-        assert randint_mock.call_count == 2
-        assert pipeline_index == proposed

--- a/tests/btb/recommendation/test_uniform_recommender.py
+++ b/tests/btb/recommendation/test_uniform_recommender.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+
+import numpy as np
+from mock import patch
+
+from btb.recommendation.uniform import UniformRecommender
+
+
+class TestBaseRecommender(TestCase):
+    def setUp(self):
+        # Set-up
+        self.dpp_matrix = np.array([
+            [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0],
+            [0, 4, 0, 6, 0, 4, 0, 2, 1, 0, 0, 2, 3, 1, 0, 0],
+            [1, 0, 1, 2, 0, 0, 6, 1, 0, 5, 1, 0, 0, 0, 0, 1],
+            [0, 2, 3, 0, 0, 0, 0, 0, 4, 1, 3, 2, 0, 0, 1, 4]
+        ])
+        self.dpp_matrix_small = np.array([
+            [1, 0, 0, 0],
+            [0, 4, 0, 6],
+            [1, 0, 1, 2],
+            [0, 2, 3, 0]
+        ])
+
+    @patch('btb.recommendation.uniform.np.random.permutation')
+    def test_predict_all(self, randpermutation_mock):
+        indicies = np.array(range(4))
+        permutation = [3, 2, 1, 4]
+        randpermutation_mock.return_value = permutation
+        recommender = UniformRecommender(self.dpp_matrix_small)
+        predictions = recommender.predict(indicies)
+        np.testing.assert_array_equal(
+            permutation,
+            predictions,
+        )
+
+    @patch('btb.recommendation.uniform.np.random.permutation')
+    def test_predict_one(self, randpermutation_mock):
+        indicies = np.array([0])
+        permutation = [1]
+        randpermutation_mock.return_value = permutation
+        recommender = UniformRecommender(self.dpp_matrix)
+        predictions = recommender.predict(indicies)
+        np.testing.assert_array_equal(
+            permutation,
+            predictions,
+        )


### PR DESCRIPTION
In order to more easily extend Recomm ender class, split logic into BaseRecommender object.  Naming/functionality matches that of Tuner.
Base class implements:

- add
- propose
- acquire
- get_candidnates
- fit (doesn't really do much)

Each extension of BaseRecommender is responsible for a predict method (at the minimum).

Added a UniformReccomender object which choses a pipeline to recommend at random.

Moved existing Recommender strategy into MFRecommender.

Added tests for all Recommender types.