### PR TITLE
First r_min recommendations are random

### DIFF
--- a/tests/btb/recommendation/test_matrix_factorization_recommender.py
+++ b/tests/btb/recommendation/test_matrix_factorization_recommender.py
@@ -9,6 +9,7 @@ from btb.recommendation.matrix_factorization import MFRecommender
 class TestBaseRecommender(TestCase):
     def setUp(self):
         self.n_components = 3
+        self.r_min = 0
         self.dpp_decomposed = np.array([
             [.0, .2, .4],
             [.8, .6, .4],
@@ -38,7 +39,11 @@ class TestBaseRecommender(TestCase):
         randint_mock.return_value = index
 
         # run
-        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        recommender = MFRecommender(
+            self.dpp_matrix,
+            self.n_components,
+            self.r_min,
+        )
 
         # asserts
         randint_mock.assert_called_once_with(4)  # 4 is self.dpp_matrix length
@@ -48,6 +53,7 @@ class TestBaseRecommender(TestCase):
         )
         np.testing.assert_array_equal(recommender.dpp_matrix, self.dpp_matrix)
         np.testing.assert_array_equal(recommender.dpp_ranked, self.dpp_ranked)
+        assert recommender.r_minimum == self.r_min
 
     @patch('btb.recommendation.matrix_factorization.NMF')
     def test_fit(self, nmf_mock):
@@ -55,7 +61,7 @@ class TestBaseRecommender(TestCase):
         n_components = 3
         dpp_vector = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         # Run
-        recommender = MFRecommender(self.dpp_matrix, n_components)
+        recommender = MFRecommender(self.dpp_matrix, n_components, self.r_min)
         i = 0
         nmf_mock().transform.return_value = self.dpp_ranked[i, :]
         recommender.fit(dpp_vector)
@@ -66,7 +72,11 @@ class TestBaseRecommender(TestCase):
 
     def test_predict_one(self):
         # Run
-        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        recommender = MFRecommender(
+            self.dpp_matrix,
+            self.n_components,
+            self.r_min,
+        )
         # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
         recommender.matching_dataset = self.dpp_matrix[0]
 
@@ -77,7 +87,11 @@ class TestBaseRecommender(TestCase):
 
     def test_predict_all_matching(self):
         # Run
-        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        recommender = MFRecommender(
+            self.dpp_matrix,
+            self.n_components,
+            self.r_min,
+        )
         # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
         recommender.matching_dataset = self.dpp_matrix[0]
         indicies = [1, 2, 3, 4, 5]
@@ -87,7 +101,11 @@ class TestBaseRecommender(TestCase):
 
     def test_predict_multiple_rankings(self):
         # Run
-        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        recommender = MFRecommender(
+            self.dpp_matrix,
+            self.n_components,
+            self.r_min,
+        )
         # matching row is [1, 0, 0, 0, 0, 0, 0, 3, 0, 4, 6, 2, 5, 0, 8, 0]
         recommender.matching_dataset = self.dpp_matrix[0]
         indicies = [0, 1, 14, 13]
@@ -95,12 +113,30 @@ class TestBaseRecommender(TestCase):
         expected = [2, 1, 3, 1]
         np.testing.assert_array_equal(predictions, expected)
 
+    @patch('btb.recommendation.matrix_factorization.UniformRecommender')
+    def test_predict_non_zero_rmin(self, uniform_mock):
+        # Run
+        indicies = [0, 1, 14, 13]
+        expected = [3, 1, 2, 1]
+        uniform_mock().predict.return_value = expected
+        recommender = MFRecommender(
+            self.dpp_matrix,
+            self.n_components,
+            1,
+        )
+        predictions = recommender.predict(indicies)
+        np.testing.assert_array_equal(predictions, expected)
+
     @patch('btb.recommendation.matrix_factorization.np.random.randint')
     def test_propose_without_add(self, randint_mock):
         index = 0
         randint_mock.return_value = index
         proposed = np.argmax(self.dpp_matrix[0])  # 14
-        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        recommender = MFRecommender(
+            self.dpp_matrix,
+            self.n_components,
+            self.r_min,
+        )
         np.testing.assert_array_equal(
             recommender.matching_dataset,
             self.dpp_matrix[index, :],
@@ -114,7 +150,11 @@ class TestBaseRecommender(TestCase):
         index = 0
         randint_mock.return_value = index
         proposed = np.argmax(self.dpp_matrix[0])  # 14
-        recommender = MFRecommender(self.dpp_matrix, self.n_components)
+        recommender = MFRecommender(
+            self.dpp_matrix,
+            self.n_components,
+            self.r_min,
+        )
         recommender.add({})
         np.testing.assert_array_equal(
             recommender.matching_dataset,


### PR DESCRIPTION
Similary to GP for Tuners, there is an attribute r_min in the matrix factorization recommender that specifies a number of random candidates to try first before using matrix factorization technique for recommendations.  Uses a Uniform Recommender to make random suggestions.