### PR TITLE
Support strings to be passed as param_type in HyperParameter constructor

### DIFF
--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -57,12 +57,12 @@ class HyperParameter(object):
         raise NotImplementedError()
 
     def __init__(self, param_type=None, param_range=None):
-        for i, value in enumerate(param_range):
-            # the value None is allowed for every parameter type
-            if value is not None:
-                param_range[i] = self.cast(value)
-
-        self.range = param_range
+        self.range = [
+            self.cast(value)
+            # "the value None is allowed for every parameter type"
+            if value is not None else None
+            for value in param_range
+        ]
 
     def __copy__(self):
         cls = self.__class__

--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -102,6 +102,22 @@ class HyperParameter(object):
             decimals=5,
         )
 
+    def __eq__(self, other):
+        # See https://stackoverflow.com/a/25176504/2514228 for details
+        if isinstance(self, other.__class__):
+            return (self.param_type is other.param_type
+                    and self.is_integer == other.is_integer
+                    and self.range == other.range)
+        return NotImplemented
+
+    def __ne__(self, other):
+        # Not needed in Python 3
+        # See https://stackoverflow.com/a/25176504/2514228 for details
+        x = self.__eq__(other)
+        if x is not NotImplemented:
+            return not x
+        return NotImplemented
+
 
 class IntHyperParameter(HyperParameter):
     param_type = ParamTypes.INT

--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -42,12 +42,16 @@ class HyperParameter(object):
         return cls._subclasses
 
     def __new__(cls, param_type=None, param_range=None):
-        if isinstance(param_type, ParamTypes):
-            for subclass in cls.subclasses():
-                if subclass.param_type is param_type:
-                    return super(HyperParameter, cls).__new__(subclass)
+        if not isinstance(param_type, ParamTypes):
+            if (isinstance(param_type, str)
+                    and param_type.upper() in ParamTypes.__members__):
+                param_type = ParamTypes(param_type.upper())
+            else:
+                raise ValueError('Invalid param type {}'.format(param_type))
 
-        raise ValueError('Invalid ParamType {}'.format(param_type))
+        for subclass in cls.subclasses():
+            if subclass.param_type is param_type:
+                return super(HyperParameter, cls).__new__(subclass)
 
     def cast(self, value):
         raise NotImplementedError()

--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -45,7 +45,7 @@ class HyperParameter(object):
         if not isinstance(param_type, ParamTypes):
             if (isinstance(param_type, str)
                     and param_type.upper() in ParamTypes.__members__):
-                param_type = ParamTypes(param_type.upper())
+                param_type = ParamTypes[param_type.upper()]
             else:
                 raise ValueError('Invalid param type {}'.format(param_type))
 

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -188,4 +188,4 @@ class TestHyperparameter(unittest.TestCase):
         invalid_param_types = ['a', 0, object(), 'integer', 'foo']
         for invalid_param_type in invalid_param_types:
             with self.assertRaises(ValueError):
-                HyperParameter(invalid_param_type, None)
+                HyperParameter(invalid_param_type, [None])

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -168,7 +168,7 @@ class TestHyperparameter(unittest.TestCase):
             # deep copy should have new attributes
             self.assertIsNot(hyp.range, hyp_copy.range)
 
-    def test_str_param_type_arg(self):
+    def test_init_with_string_param_type(self):
         def random_case(s):
             return ''.join(
                 random.choice([str.upper, str.lower])(c)

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -3,7 +3,6 @@ import random
 import unittest
 
 import numpy as np
-import pytest
 from mock import patch
 
 from btb.hyper_parameter import HyperParameter, ParamTypes
@@ -14,6 +13,7 @@ class TestHyperparameter(unittest.TestCase):
         self.parameter_constructions = [
             (ParamTypes.INT, [1, 3]),
             (ParamTypes.INT_EXP, [10, 10000]),
+            (ParamTypes.INT_CAT, [10, 10000]),
             (ParamTypes.FLOAT, [1.5, 3.2]),
             (ParamTypes.FLOAT_EXP, [0.001, 100]),
             (ParamTypes.FLOAT_CAT, [0.1, 0.6, 0.5]),
@@ -21,8 +21,8 @@ class TestHyperparameter(unittest.TestCase):
             (ParamTypes.STRING, ['a', 'b', 'c']),
         ]
 
-    def test___init__value_error(self):
-        with pytest.raises(ValueError):
+    def test_init_value_error(self):
+        with self.assertRaises(ValueError):
             HyperParameter('not a ParamType', [1, 10])
 
     @patch('btb.hyper_parameter.HyperParameter.subclasses')
@@ -37,7 +37,7 @@ class TestHyperparameter(unittest.TestCase):
 
         fake = HyperParameter(ParamTypes.INT, [None])
 
-        with pytest.raises(NotImplementedError):
+        with self.assertRaises(NotImplementedError):
             fake.cast(1)
 
     def test_int(self):

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -1,4 +1,5 @@
 import copy
+import random
 import unittest
 
 import numpy as np
@@ -166,3 +167,25 @@ class TestHyperparameter(unittest.TestCase):
 
             # deep copy should have new attributes
             self.assertIsNot(hyp.range, hyp_copy.range)
+
+    def test_str_param_type_arg(self):
+        def random_case(s):
+            return ''.join(
+                random.choice([str.upper, str.lower])(c)
+                for c in s
+            )
+
+        # allowed string param types
+        for typ, rang in self.parameter_constructions:
+            for recase in [str.upper, str.lower, random_case]:
+                str_typ = recase(typ.name)
+                self.assertEqual(
+                    HyperParameter(str_typ, rang),
+                    HyperParameter(typ, rang)
+                )
+
+        # invalid string param types
+        invalid_param_types = ['a', 0, object(), 'integer', 'foo']
+        for invalid_param_type in invalid_param_types:
+            with self.assertRaises(ValueError):
+                HyperParameter(invalid_param_type, None)


### PR DESCRIPTION
This fixes #49.
This also fixes #56 which was discovered in the process.
This also implements __eq__ and __ne__ operators for HyperParameter, which is required for testing.

The following are now equivalent
```
HyperParameter(ParamTypes.INT, [0, 10])
HyperParameter('INT', [0, 10])
HyperParameter('int', [0, 10])
```