### PR TITLE
Gh 59 remove unneeded things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/btb.rst
+docs/modules.rst
 docs/btb.*.rst
 
 # PyBuilder

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ coverage: clean-coverage ## check code coverage quickly with the default Python
 
 clean-docs: ## remove previously built docs
 	rm -f docs/btb.rst
+	rm -f docs/btb.*.rst
 	rm -f docs/modules.rst
 	$(MAKE) -C docs clean
 

--- a/docs/_path_setup.py
+++ b/docs/_path_setup.py
@@ -1,4 +1,0 @@
-import os
-import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@
 import sphinx_rtd_theme  # For read the docs theme
 from recommonmark.parser import CommonMarkParser
 
-import _path_setup  # noqa: F401
 import btb
 
 # -- General configuration ---------------------------------------------

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-btb
-===
-
-.. toctree::
-   :maxdepth: 4
-
-   btb

--- a/examples/_path_setup.py
+++ b/examples/_path_setup.py
@@ -1,4 +1,0 @@
-import os
-import sys
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.path.pardir))

--- a/examples/random_forest.py
+++ b/examples/random_forest.py
@@ -3,7 +3,6 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 
-import _path_setup  # noqa: F401
 from btb import HyperParameter, ParamTypes
 from btb.tuning import GP, Uniform
 

--- a/examples/rosenbrock.py
+++ b/examples/rosenbrock.py
@@ -1,4 +1,3 @@
-import _path_setup  # noqa: F401
 from btb import HyperParameter, ParamTypes
 from btb.tuning import GP, Uniform
 

--- a/examples/selection_example.py
+++ b/examples/selection_example.py
@@ -4,7 +4,6 @@ from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
 
-import _path_setup  # noqa: F401
 from btb import HyperParameter, ParamTypes
 from btb.selection import Selector
 from btb.tuning import GP

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,6 @@ ignore =    # Keep empty to prevent default ignores
 
 [isort]
 include_trailing_comment = True
-known_first_party = btb
-known_third_party = mock, numpy, pytest, scipy, six, sklearn
 line_length = 99
 lines_between_types = 0
 multi_line_output = 4

--- a/tox.ini
+++ b/tox.ini
@@ -14,25 +14,25 @@ python =
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements_test.txt
 commands =
-    pip install -U pip
-    pytest --basetemp={envtmpdir}
+    /usr/bin/env make test
 
 
 [testenv:flake8]
 skipsdist = true
-skip_install = true
-deps =
-    flake8
-    isort
+# skip_install = true
+# flake8
+# isort
+# deps =
+#     -r{toxinidir}/requirements_test.txt
 commands =
     /usr/bin/env make lint
 
 
 [testenv:docs]
 skipsdist = true
-setenv =
-    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements_dev.txt
 commands =
     /usr/bin/env make docs

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,8 @@ commands =
 
 [testenv:flake8]
 skipsdist = true
-# skip_install = true
-# flake8
-# isort
-# deps =
-#     -r{toxinidir}/requirements_test.txt
+deps =
+    -r{toxinidir}/requirements_dev.txt
 commands =
     /usr/bin/env make lint
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,8 @@ commands =
 
 
 [testenv:docs]
+skipsdist = true
 setenv =
     PYTHONPATH = {toxinidir}
-deps =
-    -r{toxinidir}/requirements_dev.txt
 commands =
     /usr/bin/env make docs


### PR DESCRIPTION
This resolves #59 

* Removes autogenerated rst documentation
* Cleans up tox configuration, removing unneeded commands and installing the package in every stage to prevent dependency problems.
* Cleans up isort configuration in setup.cfg and removes some hacks that were wrongly introduced to work around the bad tox configuration.
* Removes the `_path_setup.py` hack that is not needed if the package is properly installed.