### PR TITLE
Update bumpversion configuration and document release workflow

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -162,3 +162,33 @@ Tips
 To run a subset of tests::
 
     $ pytest tests.test_btb
+
+Release Workflow
+----------------
+
+The process of releasing a new version involves several steps combining both ``git`` and
+``bumpversion`` which, briefly:
+
+1. Merge what is in ``master`` branch into ``stable`` branch.
+2. Update the version in ``setup.cfg``, ``btb/__init__.py`` and ``HISTORY.md`` files.
+3. Create a new TAG pointing at the correspoding commit in ``stable`` branch.
+4. Merge the new commit from ``stable`` into ``master``.
+5. Update the version in ``setup.cfg`` and ``btb/__init__.py`` to open the next
+   development interation.
+
+**Note:** Before starting the process, make sure that ``HISTORY.md`` has a section titled
+**Unreleased** with the list of changes that will be included in the new version, and that
+these changes are committed and available in ``master`` branch.
+Normally this is just a list of the Pull Requests that have been merged since the latest version.
+
+Once this is done, just run the following commands:
+
+    git checkout stable
+    git merge --no-ff master    # This creates a merge commit
+    bumpversion release   # This creates a new commit and a TAG
+    git push --tags origin stable
+    make release
+    git checkout master
+    git merge stable
+    bumpversion --no-tag minor
+    git push

--- a/btb/__init__.py
+++ b/btb/__init__.py
@@ -7,7 +7,7 @@
 
 __author__ = 'MIT Data To AI Lab'
 __email__ = 'dailabmit@gmail.com',
-__version__ = '0.1.0'
+__version__ = '0.2.0-dev'
 
 import logging
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,21 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.2.0-dev
 commit = True
 tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+serialize =
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = release
+values =
+	dev
+	release
+
+[bumpversion:file:HISTORY.md]
+search = Unreleased
+replace = {new_version}
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'
@@ -17,7 +31,7 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = .tox, .git, __pycache__, .ipynb_checkpoints
-ignore =    # Keep empty to prevent default ignores
+ignore =  # Keep empty to prevent default ignores
 
 [isort]
 include_trailing_comment = True
@@ -28,7 +42,6 @@ not_skip = __init__.py
 use_parentheses = True
 
 [aliases]
-# Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/HDI-Project/BTB',
-    version='0.1.1',
+    version='0.2.0-dev',
     zip_safe=False,
 )


### PR DESCRIPTION
This includes the changes in the `setup.cfg` file and the documentation of the steps in the `HISTORY.md` file, but it still does not include the automation in the `Makefile` because I prefer to test the steps manually for the next release.

Once we know for sure that the steps are correct, I will add them to the `Makefile`