### PR TITLE
Add support for unicode param_type on py2

### DIFF
--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from enum import Enum
 
 import numpy as np
+import six
 
 
 class ParamTypes(Enum):
@@ -43,7 +44,7 @@ class HyperParameter(object):
 
     def __new__(cls, param_type=None, param_range=None):
         if not isinstance(param_type, ParamTypes):
-            if (isinstance(param_type, str) and
+            if (isinstance(param_type, six.string_types) and
                     param_type.upper() in ParamTypes.__members__):
                 param_type = ParamTypes[param_type.upper()]
             else:
@@ -103,7 +104,7 @@ class HyperParameter(object):
         )
 
     def __eq__(self, other):
-        # See https://stackoverflow.com/a/25176504/2514228 for details
+        # See https://stackoverflow.com/a/25176504 for details
         if isinstance(self, other.__class__):
             return (self.param_type is other.param_type and
                     self.is_integer == other.is_integer and
@@ -112,7 +113,7 @@ class HyperParameter(object):
 
     def __ne__(self, other):
         # Not needed in Python 3
-        # See https://stackoverflow.com/a/25176504/2514228 for details
+        # See https://stackoverflow.com/a/25176504 for details
         x = self.__eq__(other)
         if x is not NotImplemented:
             return not x

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ install_requires = [
     'enum34>=1.1.6; python_version=="2.7"',
     'numpy>=1.14.2',
     'scikit-learn>=0.19.1',
-    'scipy>=1.0.1'
+    'scipy>=1.0.1',
+    'six>=1.0',
 ]
 
 tests_require = [

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -187,6 +187,15 @@ class TestHyperparameter(unittest.TestCase):
                     HyperParameter(type_, range_)
                 )
 
+    def test_init_with_unicode_param_type(self):
+        param_type_str = 'int'
+        param_type_unicode = u'int'
+        param_range = [0, 10]
+
+        self.assertEqual(
+            HyperParameter(param_type_unicode, param_range),
+            HyperParameter(param_type_str, param_range))
+
     def test_init_with_string_param_type_invalid(self):
         # invalid string param types
         invalid_param_types = ['a', 0, object(), 'integer', 'foo']


### PR DESCRIPTION
Easy enough -- just check for `six.string_types` instead of `str`.

Fixes #93 