### PR TITLE
Fix BestK implementations

### DIFF
--- a/btb/selection/best.py
+++ b/btb/selection/best.py
@@ -1,5 +1,7 @@
 import logging
 
+import numpy as np
+
 from btb.selection.ucb1 import UCB1
 
 # the minimum number of scores that each choice must have in order to use best-K
@@ -24,10 +26,11 @@ class BestKReward(UCB1):
     def compute_rewards(self, scores):
         """Retain the K best scores, and replace the rest with zeros"""
         if len(scores) > self.k:
-            kth_best = sorted(scores, reverse=True)[self.k - 1]
-            return [(s if s >= kth_best else 0.) for s in scores]
-        else:
-            return list(scores)
+            scores = np.copy(scores)
+            inds = np.argsort(scores)[:-self.k]
+            scores[inds] = 0.0
+
+        return list(scores)
 
     def select(self, choice_scores):
         """

--- a/btb/selection/best.py
+++ b/btb/selection/best.py
@@ -39,7 +39,7 @@ class BestKReward(UCB1):
         """
         # if we don't have enough scores to do K-selection, use the default UCB1
         # reward function
-        min_num_scores = min([len(s) for s in choice_scores.values()])
+        min_num_scores = min(len(s) for s in choice_scores.values())
         if min_num_scores >= K_MIN:
             logger.info(
                 '{klass}: using Best K bandit selection'

--- a/btb/selection/best.py
+++ b/btb/selection/best.py
@@ -69,16 +69,13 @@ class BestKVelocity(BestKReward):
     """Best K velocity selector"""
 
     def compute_rewards(self, scores):
-        """
-        Compute the "velocity" of (average distance between) the k+1 best
-        scores. Return a list with those k velocities padded out with zeros so
-        that the count remains the same.
-        """
-        # get the k + 1 best scores in descending order
-        best_scores = sorted(scores, reverse=True)[:self.k + 1]
-        velocities = [best_scores[i] - best_scores[i + 1]
-                      for i in range(len(best_scores) - 1)]
+        """Compute the velocity of the best scores
 
-        # pad the list out with zeros to maintain the length of the list
-        zeros = (len(scores) - self.k) * [0]
-        return velocities + zeros
+        The velocities are the k distances between the k+1 best scores.
+        """
+        k = self.k
+        m = max(len(scores) - k, 0)
+        best_scores = sorted(scores)[-k - 1:]
+        velocities = np.diff(best_scores)
+        nans = np.full(m, np.nan)
+        return list(velocities) + list(nans)

--- a/btb/selection/ucb1.py
+++ b/btb/selection/ucb1.py
@@ -11,7 +11,7 @@ class UCB1(Selector):
 
     See also::
 
-       Auer, Peter et al. “Finite-time Analysis of the Multiarmed Bandit Problem.”
+       Auer, Peter et al. "Finite-time Analysis of the Multiarmed Bandit Problem."
        Machine Learning 47 (2002): 235-256.
     """
 

--- a/btb/util.py
+++ b/btb/util.py
@@ -1,0 +1,9 @@
+import random
+
+
+def shuffle(iterable):
+    iterable = list(iterable)
+    inds = list(range(len(iterable)))
+    random.shuffle(inds)
+    for i in inds:
+        yield iterable[i]

--- a/tests/btb/selection/test_best.py
+++ b/tests/btb/selection/test_best.py
@@ -50,6 +50,14 @@ class TestBestKReward(TestCase):
         # Assert
         assert rewards == [0.83, 0.0, 0.86, 0.9]
 
+    def test_compute_rewards_duplicates(self):
+        k=3
+        choices = ['RF', 'SVM']
+        scores = [0.7, 0.8, 0.7, 0.1, 0.8, 0.7]
+        selector = BestKReward(choices, k=k)
+        rewards = selector.compute_rewards(scores)
+        assert sorted(rewards) == [0.0, 0.0, 0.0, 0.7, 0.8, 0.8]
+
     # METHOD: select(self, choice_scores)
     # VALIDATE:
     #     * Returned values for multiple cases

--- a/tests/btb/selection/test_best.py
+++ b/tests/btb/selection/test_best.py
@@ -51,7 +51,7 @@ class TestBestKReward(TestCase):
         assert rewards == [0.83, 0.0, 0.86, 0.9]
 
     def test_compute_rewards_duplicates(self):
-        k=3
+        k = 3
         choices = ['RF', 'SVM']
         scores = [0.7, 0.8, 0.7, 0.1, 0.8, 0.7]
         selector = BestKReward(choices, k=k)

--- a/tests/btb/selection/test_best.py
+++ b/tests/btb/selection/test_best.py
@@ -48,7 +48,7 @@ class TestBestKReward(TestCase):
         rewards = selector.compute_rewards(scores)
 
         # Assert
-        assert rewards == [0.83, 0.0, 0.86, 0.9]
+        np.testing.assert_array_equal(rewards, [0.83, np.nan, 0.86, 0.9])
 
     def test_compute_rewards_duplicates(self):
         k = 3
@@ -56,7 +56,10 @@ class TestBestKReward(TestCase):
         scores = [0.7, 0.8, 0.7, 0.1, 0.8, 0.7]
         selector = BestKReward(choices, k=k)
         rewards = selector.compute_rewards(scores)
-        assert sorted(rewards) == [0.0, 0.0, 0.0, 0.7, 0.8, 0.8]
+        np.testing.assert_array_equal(
+            np.sort(rewards),
+            np.sort([np.nan, np.nan, np.nan, 0.7, 0.8, 0.8])
+        )
 
     # METHOD: select(self, choice_scores)
     # VALIDATE:
@@ -71,7 +74,7 @@ class TestBestKReward(TestCase):
     def test_select_more_scores_than_k_min(self, bandit_mock):
         """If min length is gt k_min, self.compute_rewards is used.
 
-        In this case, we expect the lower scores to be zeroed.
+        In this case, we expect the lower scores to be nan.
         """
 
         # Set-up
@@ -90,11 +93,19 @@ class TestBestKReward(TestCase):
         # Assert
         assert best == 'SVM'
 
-        choice_rewards = {
-            'RF': [0., 0.85, 0.83],
-            'SVM': [0., 0.95, 0.93],
+        choice_rewards_expected = {
+            'RF': [np.nan, 0.85, 0.83],
+            'SVM': [np.nan, 0.95, 0.93],
         }
-        bandit_mock.assert_called_once_with(choice_rewards)
+        # TODO
+        (choice_rewards, ), _ = bandit_mock.call_args
+        assert choice_rewards.keys() == choice_rewards_expected.keys()
+        for k in choice_rewards:
+            assert k in choice_rewards_expected
+            np.testing.assert_array_equal(
+                choice_rewards[k],
+                choice_rewards_expected[k]
+            )
 
     @patch('btb.selection.best.BestKReward.bandit')
     def test_select_less_scores_than_k_min(self, bandit_mock):
@@ -143,7 +154,10 @@ class TestBestKVelocity(TestCase):
         rewards = selector.compute_rewards(scores)
 
         # Assert
-        np.testing.assert_allclose(rewards, [0.05, 0.15, 0.1])
+        np.testing.assert_allclose(
+            np.sort(rewards),
+            np.sort([0.05, 0.15, 0.1])
+        )
 
     def test_compute_rewards_gt_k(self):
         """More scores than self.k: padding"""
@@ -156,4 +170,7 @@ class TestBestKVelocity(TestCase):
         rewards = selector.compute_rewards(scores)
 
         # Assert
-        np.testing.assert_allclose(rewards, [0.05, 0.15, 0.1, 0., 0.])
+        np.testing.assert_allclose(
+            np.sort(rewards),
+            np.sort([0.05, 0.15, 0.1, np.nan, np.nan])
+        )

--- a/tests/btb/selection/test_ucb1.py
+++ b/tests/btb/selection/test_ucb1.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from unittest import TestCase
 
 from mock import patch
@@ -10,32 +9,29 @@ class TestUCB1(TestCase):
 
     # METHOD: bandit(self, choice_rewards)
     # VALIDATE:
-    #     * returned balues
+    #     * returned values
     # NOTES:
     #     * random.choice will need to be mocked
 
-    @patch('btb.selection.ucb1.random')
-    def test_bandit(self, random_mock):
+    @patch('btb.selection.ucb1.shuffle')
+    def test_bandit(self, mock_shuffle):
         """Only the choices with the highest scores are returned."""
+        choices = ['DT', 'SVM', 'RF']
+        mock_shuffle.return_value = choices
 
         # Set-up
-        selector = UCB1(['DT', 'RF', 'SVM'])
-
-        random_mock.choice.return_value = 'SVM'
+        selector = UCB1(choices)
 
         # Run
-        choice_rewards = OrderedDict((
-            ('DT', [0.7, 0.8, 0.9]),
-            ('RF', [0.9, 0.93, 0.95]),
-            ('SVM', [0.9, 0.93, 0.95])
-        ))
+        choice_rewards = {
+            'DT': [0.7, 0.8, 0.9],
+            'RF': [0.9, 0.93, 0.95],
+            'SVM': [0.9, 0.93, 0.95]
+        }
 
-        # We patch dict as OrderedDict to preserve the order
-        # in .items() and make the later assert simpler.
-        # Otherwise, we could not rely on the list order.
-        with patch('btb.selection.ucb1.dict', new=OrderedDict):
-            best = selector.bandit(choice_rewards)
+        best = selector.bandit(choice_rewards)
 
         # Assert
+        # The first choice tried wins if there are duplicate max scores
         assert best == 'SVM'
-        random_mock.choice.assert_called_once_with(['RF', 'SVM'])
+        mock_shuffle.assert_called_once()


### PR DESCRIPTION
Fix the logic behind `BestKReward` and `BestKVelocity`.
- Select exactly `k` best values, rather than all values that are equal to the `k` largest unique values.
- Do not use the deselected scores in computing the average reward (set them to `np.nan` instead)
- Clean up implementation

Closes #89 