### PR TITLE
Fix pickling of HyperParameters

### DIFF
--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -1,4 +1,3 @@
-import copy
 import math
 import random
 from collections import defaultdict
@@ -68,24 +67,6 @@ class HyperParameter(object):
             if value is not None else None
             for value in param_range
         ]
-
-    def __copy__(self):
-        cls = self.__class__
-        result = cls.__new__(cls, self.param_type, self.range)
-        result.__dict__.update(self.__dict__)
-        return result
-
-    def __deepcopy__(self, memo):
-        cls = self.__class__
-        result = cls.__new__(cls, self.param_type, self.range)
-        result.__dict__.update(self.__dict__)
-
-        memo[id(self)] = result
-
-        for k, v in self.__dict__.items():
-            setattr(result, k, copy.deepcopy(v, memo))
-
-        return result
 
     def fit_transform(self, x, y):
         return x

--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -58,6 +58,10 @@ class HyperParameter(object):
         raise NotImplementedError()
 
     def __init__(self, param_type=None, param_range=None):
+        # maintain original param_range
+        self._param_range = param_range
+
+        # transformed range
         self.range = [
             self.cast(value)
             # "the value None is allowed for every parameter type"
@@ -120,6 +124,10 @@ class HyperParameter(object):
         return NotImplemented
 
 
+    def __getnewargs__(self):
+        return (self.param_type, self._param_range)
+
+
 class IntHyperParameter(HyperParameter):
     param_type = ParamTypes.INT
     is_integer = True
@@ -163,6 +171,7 @@ class IntExpHyperParameter(FloatExpHyperParameter):
 class CatHyperParameter(HyperParameter):
 
     def __init__(self, param_type=None, param_range=None):
+        super(CatHyperParameter, self).__init__(param_type, param_range)
         self.cat_transform = {self.cast(each): 0 for each in param_range}
         self.range = [0.0, 1.0]
 

--- a/btb/hyper_parameter.py
+++ b/btb/hyper_parameter.py
@@ -123,7 +123,6 @@ class HyperParameter(object):
             return not x
         return NotImplemented
 
-
     def __getnewargs__(self):
         return (self.param_type, self._param_range)
 

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -1,7 +1,6 @@
 import copy
 import pickle
 import random
-import tempfile
 import unittest
 
 import numpy as np
@@ -206,7 +205,7 @@ class TestHyperparameter(unittest.TestCase):
                 HyperParameter(invalid_param_type, [None])
 
     def test_can_pickle(self):
-        for protocol in range(0, pickle.HIGHEST_PROTOCOL+1):
+        for protocol in range(0, pickle.HIGHEST_PROTOCOL + 1):
             for param_type, param_range in self.parameter_constructions:
                 param = HyperParameter(param_type, param_range)
                 pickled = pickle.dumps(param, protocol)

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -205,10 +205,10 @@ class TestHyperparameter(unittest.TestCase):
             with self.assertRaises(ValueError):
                 HyperParameter(invalid_param_type, [None])
 
-    @unittest.expectedFailure
     def test_can_pickle(self):
-        for param_type, param_range in self.parameter_constructions:
-            param = HyperParameter(param_type, param_range)
-            pickled = pickle.dumps(param, pickle.HIGHEST_PROTOCOL)
-            unpickled = pickle.loads(pickled)
-            self.assertEqual(param, unpickled)
+        for protocol in range(0, pickle.HIGHEST_PROTOCOL+1):
+            for param_type, param_range in self.parameter_constructions:
+                param = HyperParameter(param_type, param_range)
+                pickled = pickle.dumps(param, protocol)
+                unpickled = pickle.loads(pickled)
+                self.assertEqual(param, unpickled)

--- a/tests/btb/test_hyper_parameter.py
+++ b/tests/btb/test_hyper_parameter.py
@@ -1,5 +1,7 @@
 import copy
+import pickle
 import random
+import tempfile
 import unittest
 
 import numpy as np
@@ -202,3 +204,11 @@ class TestHyperparameter(unittest.TestCase):
         for invalid_param_type in invalid_param_types:
             with self.assertRaises(ValueError):
                 HyperParameter(invalid_param_type, [None])
+
+    @unittest.expectedFailure
+    def test_can_pickle(self):
+        for param_type, param_range in self.parameter_constructions:
+            param = HyperParameter(param_type, param_range)
+            pickled = pickle.dumps(param, pickle.HIGHEST_PROTOCOL)
+            unpickled = pickle.loads(pickled)
+            self.assertEqual(param, unpickled)


### PR DESCRIPTION
`HyperParameter` objects were unable to be pickled using pickling protocol 2 (`pickle.HIGHEST_PROTOCOL`). The reason is that unpickling (as well as copying) first creates a new instance of the class and then sets its state to match the old state. Our use of `HyperParameter` as a metaclass where `__new__` takes arguments conflicts with this. The solution is to implement `__getnewargs__` which allows arguments to be passed to `__new__`.

See also 
- https://docs.python.org/3/library/pickle.html#pickling-class-instances
- https://www.python.org/dev/peps/pep-0307/#case-3-pickling-new-style-class-instances-using-protocol-2.

Fixes #96 
