### PR TITLE
Issue 133 implement tunable class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test: ## run tests quickly with the default Python
 
 .PHONY: test-all
 test-all: ## run tests on every Python version with tox
-	tox
+	tox -r
 
 .PHONY: coverage
 coverage: ## check code coverage quickly with the default Python

--- a/btb/tuning/hyperparams/base.py
+++ b/btb/tuning/hyperparams/base.py
@@ -106,7 +106,7 @@ class BaseHyperParam(metaclass=ABCMeta):
             values (numpy.ndarray):
                 2D array of values that will be validated.
         """
-        self._within_range(values, min=0, max=1)
+        self._within_range(values.astype(np.float), min=0, max=1)
 
     @abstractmethod
     def _inverse_transform(self, values):

--- a/btb/tuning/hyperparams/boolean.py
+++ b/btb/tuning/hyperparams/boolean.py
@@ -21,8 +21,10 @@ class BooleanHyperParam(BaseHyperParam):
     K = 1
 
     def _within_hyperparam_space(self, values):
-        if values.dtype is not np.dtype('bool'):
-            raise ValueError('Values: {} not within hyperparameter space.'.format(values))
+        # values is expected to be np.ndarray(n, 1) [[False], [True]]
+        if not all(isinstance(value[0], bool) for value in values):
+            if values.dtype is not np.dtype('bool'):
+                raise ValueError('Values: {} not within hyperparameter space.'.format(values))
 
     def _inverse_transform(self, values):
         """Invert one or more search space values.

--- a/btb/tuning/hyperparams/boolean.py
+++ b/btb/tuning/hyperparams/boolean.py
@@ -21,9 +21,9 @@ class BooleanHyperParam(BaseHyperParam):
     K = 1
 
     def _within_hyperparam_space(self, values):
-        # values is expected to be np.ndarray(n, 1) [[False], [True]]
-        if not all(isinstance(value[0], bool) for value in values):
-            if values.dtype is not np.dtype('bool'):
+        if values.dtype is not np.dtype('bool'):
+            # values is expected to be np.ndarray(n, 1) [[False], [True]]
+            if not all(isinstance(value[0], bool) for value in values):
                 raise ValueError('Values: {} not within hyperparameter space.'.format(values))
 
     def _inverse_transform(self, values):

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -11,26 +11,26 @@ class Tunable:
 
     The Tunable class contains a collection of hyperparameters and metadata related to them. Is
     able to control this collection and work with the hyperparameters defined as a bulk.
-    This class has the same public methods as ``BaseHyperParam``. Keep in mind that a certain
-    order should be followed during the usage of this class, which is defined by ``self.names``.
-    This is the expected order to recive the values by the ``inverse_transform`` method.
+    This class has the same public methods as ``BaseHyperParam``.
 
     Attributes:
         hyperparams:
             Dict of hyperparameters.
         names:
-            List of names that the hyperparameters have.
+            List of names that the hyperparameters have and act as an ordering during the usage
+            of ``inverse_transform`` method.
+
+    Args:
+        hyperparams (dict):
+            Dictionary object that contains the name and the hyperparameter asociated to it.
+        names (list):
+            List of names to be used as order during ``inverse_transform``. If this value is
+            ``None``, the default order from the dictionary will be used.
     """
 
     def __init__(self, hyperparams, names=None):
         """Creates an instance of a Tunable class.
 
-        Args:
-            hyperparams (dict):
-                Dictionary object that contains the name and the hyperparameter asociated to it.
-            names (list):
-                List of names to be used as order during ``inverse_transform``. If this value is
-                ``None``, the default order from the dictionary will be used.
         """
 
         self.hyperparams = hyperparams
@@ -52,8 +52,8 @@ class Tunable:
 
         Returns:
             numpy.ndarray:
-                2D array of shape ``(len(values), K)`` where ``K`` is the sum of the dimensions
-                of all hyperparameters that compose this tunable.
+                2D array of shape ``(len(values), K)`` where ``K`` is the sum of dimensions that
+                are defined in each ``hyperparameter`` that composes this ``tunable``.
 
         Example:
             The example below shows a simple usage of a Tunable class which will transform a valid
@@ -71,7 +71,7 @@ class Tunable:
             ...     'ihp': ihp
             ... }
             >>> names = ['chp', 'bhp', 'ihp']
-            >>> tunable = Tunable(hyperparams=hyperparams, names=names)
+            >>> tunable = Tunable(hyperparams, names=names)
             >>> values = [
             ...     ['cat', False, 10],
             ...     ['dog', True, 1],
@@ -112,8 +112,9 @@ class Tunable:
 
         Args:
             values (ArrayLike):
-                2D array of normalized values with shape ``(n, K)`` where ``K`` is the sum of the
-                dimensions of all hyperparameters that compose this tunable.
+                2D array of normalized values with shape ``(n, K)`` where ``K`` is the sum of
+                dimensions that are defined in each ``hyperparameter`` that composes this
+                ``tunable``.
 
         Returns:
             pandas.DataFrame
@@ -134,7 +135,7 @@ class Tunable:
             ...     'ihp': ihp
             ... }
             >>> names = ['chp', 'bhp', 'ihp']
-            >>> tunable = Tunable(hyperparams=hyperparams, names=names)
+            >>> tunable = Tunable(hyperparams, names=names)
             >>> values = [
             ...     [1, 0, 0, 0.95],
             ...     [0, 1, 1, 0.05]
@@ -170,8 +171,8 @@ class Tunable:
 
         Returns:
             numpy.ndarray:
-                2D array with shape of ``(n_samples, K))`` where ``K`` is the sum of the dimensions
-                of all hyperparameters that compose this tunable.
+                2D array with shape of ``(n_samples, K))`` where ``K``  is the sum of dimensions
+                that are defined in each ``hyperparameter`` that composes this ``tunable``.
 
         Example:
             The example below shows a simple usage of a Tunable class which will generate 2
@@ -189,7 +190,7 @@ class Tunable:
             ...     'ihp': ihp
             ... }
             >>> names = ['chp', 'bhp', 'ihp']
-            >>> tunable = Tunable(hyperparams=hyperparams, names=names)
+            >>> tunable = Tunable(hyperparams, names=names)
             >>> tunable.sample(2)
             array([[0.  , 1.  , 0.  , 0.45],
                    [1.  , 0.  , 1.  , 0.95]])

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -9,12 +9,11 @@ import pandas as pd
 class Tunable:
     """Tunable class.
 
-    The Tunable class contains a collection of hyperparameters and metadata related to them, is
+    The Tunable class contains a collection of hyperparameters and metadata related to them. Is
     able to control this collection and work with the hyperparameters defined as a bulk.
     This class has the same public methods as ``BaseHyperParam``. Keep in mind that a certain
     order should be followed during the usage of this class, which is defined by ``self.names``.
-    This is the expected order of hyperparameter values that are expected to be recived by the
-    methods.
+    This is the expected order to recive the values by the ``inverse_transform`` method.
 
     Attributes:
         hyperparams:
@@ -30,9 +29,8 @@ class Tunable:
             hyperparams (dict):
                 Dictionary object that contains the name and the hyperparameter asociated to it.
             names (list):
-                List of names to be used as order during inverse_transform. If this value is
-                ``None``, the default order from the dictionary will be used. Be aware that
-                ``self.names`` gives the correct order for the transformed data.
+                List of names to be used as order during ``inverse_transform``. If this value is
+                ``None``, the default order from the dictionary will be used.
         """
 
         self.hyperparams = hyperparams
@@ -46,21 +44,21 @@ class Tunable:
         """Transform one or more hyperparameter value combinations.
 
         Transform one or more hyperparameter value combinations from the original hyperparameter
-        space to the normalized searc space.
+        space to the normalized search space.
 
         Args:
             values (pandas.DataFrame, pandas.Series, dict, list(dict), 2D ArrayLike):
-                Values of shape (n, len(self.hyperparameters)).
+                Values of shape ``(n, len(self.hyperparameters))``.
 
         Returns:
             numpy.ndarray:
-                2D array of shape (len(values), K)
+                2D array of shape ``(len(values), K)`` where ``K`` is the sum of the dimensions
+                of all hyperparameters that compose this tunable.
 
         Example:
             The example below shows a simple usage of a Tunable class which will transform a valid
             data from a 2D list and a ``numpy.ndarray`` is being returned.
 
-            >>> from btb.tuning.tunable import Tunable
             >>> from btb.tuning.hyperparams.boolean import BooleanHyperParam
             >>> from btb.tuning.hyperparams.categorical import CategoricalHyperParam
             >>> from btb.tuning.hyperparams.numerical import IntHyperParam
@@ -84,12 +82,16 @@ class Tunable:
         """
         if isinstance(values, dict):
             values = pd.DataFrame([values])
+
         elif isinstance(values, list) and isinstance(values[0], dict):
             values = pd.DataFrame(values, columns=self.names)
+
         elif isinstance(values, list) and not isinstance(values[0], list):
             values = pd.DataFrame([values], columns=self.names)
+
         elif isinstance(values, pd.Series):
             values = values.to_frame().T
+
         elif not isinstance(values, pd.DataFrame):
             values = pd.DataFrame(values, columns=self.names)
 
@@ -105,21 +107,21 @@ class Tunable:
     def inverse_transform(self, values):
         """Inverse transform one or more hyperparameter value combinations.
 
-        Transform one or more hyperparameter values from the normalized search space [0, 1]^K to
-        the original hyperparameter space.
+        Transform one or more hyperparameter values from the normalized search space
+        :math:`[0, 1]^K` to the original hyperparameter space.
 
         Args:
             values (ArrayLike):
-                2D array of normalized values with shape (n, K).
+                2D array of normalized values with shape ``(n, K)`` where ``K`` is the sum of the
+                dimensions of all hyperparameters that compose this tunable.
 
         Returns:
             pandas.DataFrame
 
         Example:
             The example below shows a simple usage of a Tunable class which will inverse transform
-            a valid data from a 2D list and a ``pandas.DataFrame`` is being returned.
+            a valid data from a 2D list and a ``pandas.DataFrame`` will be returned.
 
-            >>> from btb.tuning.tunable import Tunable
             >>> from btb.tuning.hyperparams.boolean import BooleanHyperParam
             >>> from btb.tuning.hyperparams.categorical import CategoricalHyperParam
             >>> from btb.tuning.hyperparams.numerical import IntHyperParam
@@ -154,7 +156,7 @@ class Tunable:
                 transformed.append(hyperparam.inverse_transform(item))
                 value = value[hyperparam.K:]
 
-            transformed = np.array(transformed, dtype=object)  # perserve the original dtypes
+            transformed = np.array(transformed, dtype=object)
             inverse_transform.append(np.concatenate(transformed, axis=1))
 
         return pd.DataFrame(np.concatenate(inverse_transform), columns=self.names)
@@ -168,13 +170,13 @@ class Tunable:
 
         Returns:
             numpy.ndarray:
-                2D array with shape of (n_samples, sum(hyperparams.K)).
+                2D array with shape of ``(n_samples, K))`` where ``K`` is the sum of the dimensions
+                of all hyperparameters that compose this tunable.
 
         Example:
             The example below shows a simple usage of a Tunable class which will generate 2
             samples by calling it's sample method. This will return a ``numpy.ndarray``.
 
-            >>> from btb.tuning.tunable import Tunable
             >>> from btb.tuning.hyperparams.boolean import BooleanHyperParam
             >>> from btb.tuning.hyperparams.categorical import CategoricalHyperParam
             >>> from btb.tuning.hyperparams.numerical import IntHyperParam
@@ -199,12 +201,3 @@ class Tunable:
             samples.append(items)
 
         return np.concatenate(samples, axis=1)
-
-    def to_dict(self):
-        """Get a dict representation of this Tunable."""
-        pass
-
-    @classmethod
-    def from_dict(cls, spec_dict):
-        """Load a Tunable from a dict representation."""
-        pass

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -43,7 +43,7 @@ class Tunable:
         space to the normalized search space.
 
         Args:
-            values (pandas.DataFrame, pandas.Series, dict, list(dict), 2D ArrayLike):
+            values (pandas.DataFrame, pandas.Series, dict, list(dict), 2D array-like):
                 Values of shape ``(n, len(self.hyperparameters))``.
 
         Returns:
@@ -107,7 +107,7 @@ class Tunable:
         :math:`[0, 1]^K` to the original hyperparameter space.
 
         Args:
-            values (ArrayLike):
+            values (array-like):
                 2D array of normalized values with shape ``(n, K)`` where ``K`` is the sum of
                 dimensions from each ``hyperparameter`` that composes this ``tunable``.
 

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
+import pandas as pd
+
 
 class Tunable:
     """Tunable class.
@@ -7,12 +10,28 @@ class Tunable:
     Collection of HyperParams that need to be tuned as a whole.
 
     Attributes:
-        hyperparams:
-            List of hyperparameters from this hyperparam space.
+        hyperparams: List of hyperparameters from this hyperparam space.
     """
 
-    def __init__(self, hyperparams):
+    def __init__(self, hyperparams, names=None):
+        """Creates an instance of a Tunable class.
+
+        Args:
+            hyperparams(dictLike):
+                Dictionary like object that contains the name and the hyperparameter asociated to
+                it.
+            names(list):
+                List of names to be used as order during inverse_transform. If this value is None,
+                the default order from the dictionary will be used. You should check ``self.names``
+                so you can give the correct order of your transformed data.
+        """
+
         self.hyperparams = hyperparams
+
+        if names is None:
+            names = list(hyperparams)
+
+        self.names = names
 
     def transform(self, values):
         """Transform one or more hyperparameter value combinations.
@@ -21,37 +40,79 @@ class Tunable:
         space the normalized search space [0, 1]^K.
 
         Args:
-            values (ArrayLike): 2D array of shape (*, len(self.hyperparameters)).
+            values (pandas.DataFrame, pandas.Series, dict, list(dict), 2D ArrayLike):
+                Values of shape (*, len(self.hyperparameters)).
 
         Returns:
-            transformed (ArrayLike): 2D array of shape (len(values), K)
+            transformed (ArrayLike):
+                2D array of shape (len(values), K)
         """
-        pass
+        if isinstance(values, dict):
+            values = pd.DataFrame([values])
+        elif isinstance(values, list) and isinstance(values[0], dict):
+            values = pd.DataFrame(values, columns=self.names)
+        elif isinstance(values, pd.Series):
+            values = values.to_frame().T
+        elif not isinstance(values, pd.DataFrame):
+            values = pd.DataFrame(values, columns=self.names)
+
+        transformed = list()
+
+        for name in self.names:
+            hyperparam = self.hyperparams[name]
+            value = values[name].values
+            transformed.append(hyperparam.transform(value))
+
+        return np.concatenate(transformed, axis=1)
 
     def inverse_transform(self, values):
-        """Rever one or more hyperparameter value combinations.
+        """Inverse transform one or more hyperparameter value combinations.
 
         Transform one or more hyperparameter values from the normalized search space [0, 1]^K to
         the original hyperparameter space.
 
         Args:
-            values (ArrayLike): 2D array of normalized values with shape (*, K).
+            values (ArrayLike):
+                2D array of normalized values with shape (*, K).
 
         Returns:
-            reversed (ArrayLike): 2D array of shape (len(values), len(self.hyperparameters)).
+            pandas.DataFrame
         """
-        pass
+
+        inverse_transform = list()
+
+        for value in values:
+            transformed = list()
+
+            for name in self.names:
+                hyperparam = self.hyperparams[name]
+                item = value[:hyperparam.K]
+                transformed.append(hyperparam.inverse_transform(item))
+                value = value[hyperparam.K:]
+
+            transformed = np.array(transformed, dtype=object)  # perserve the original dtypes
+            inverse_transform.append(np.concatenate(transformed, axis=1))
+
+        return pd.DataFrame(np.concatenate(inverse_transform), columns=self.names)
 
     def sample(self, n_samples):
-        """Sample values in this hyperparameter search space.
+        """Generate sample values for this hyperparameters.
 
         Args:
-            n_samlpes (int): Number of values to sample.
+            n_samlpes (int):
+                Number of values to sample.
 
         Returns:
-            samples (ArrayLike): 2D array with shape of (n_samples, self._k).
+            samples (ArrayLike):
+                2D array with shape of (n_samples, sum(hyperparams.K)).
         """
-        pass
+        samples = list()
+
+        for name, hyperparam in self.hyperparams.items():
+            items = hyperparam.sample(n_samples)
+            samples.append(items)
+
+        return np.concatenate(samples, axis=1)
 
     def to_dict(self):
         """Get a dict representation of this Tunable."""

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -9,9 +9,8 @@ import pandas as pd
 class Tunable:
     """Tunable class.
 
-    This class is able to control a collection of ``hyperparameters`` and work with them as a
-    bulk. The class can ``transform``, ``inverse_transform`` and ``sample`` combinations of values
-    for the ``hyperparameters`` that compose the instance.
+    The Tunable class represents a collection of ``hyperparameters`` that need to be tuned as a
+    whole, at once.
 
     Attributes:
         hyperparams:
@@ -93,9 +92,9 @@ class Tunable:
         return np.concatenate(transformed, axis=1)
 
     def inverse_transform(self, values):
-        """Inverse transform one or more value combinations.
+        """Invert one or more value combinations.
 
-        Inverse transform one or more hyperparameter value combinations from the normalized search
+        Invert one or more hyperparameter value combinations from the normalized search
         space :math:`[0, 1]^K` to the original hyperparameter space.
 
         Args:
@@ -149,7 +148,7 @@ class Tunable:
         return pd.DataFrame(np.concatenate(inverse_transform), columns=self.names)
 
     def sample(self, n_samples):
-        """Generate sample values for this hyperparameters.
+        """Sample values in the hyperparameters spaces for this tunable.
 
         Args:
             n_samlpes (int):

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -29,10 +29,6 @@ class Tunable:
     """
 
     def __init__(self, hyperparams, names=None):
-        """Creates an instance of a Tunable class.
-
-        """
-
         self.hyperparams = hyperparams
 
         if names is None:
@@ -52,8 +48,8 @@ class Tunable:
 
         Returns:
             numpy.ndarray:
-                2D array of shape ``(len(values), K)`` where ``K`` is the sum of dimensions that
-                are defined in each ``hyperparameter`` that composes this ``tunable``.
+                2D array of shape ``(len(values), K)`` where ``K`` is the sum of dimensions from
+                each ``hyperparameter`` that composes this ``tunable``.
 
         Example:
             The example below shows a simple usage of a Tunable class which will transform a valid
@@ -113,8 +109,7 @@ class Tunable:
         Args:
             values (ArrayLike):
                 2D array of normalized values with shape ``(n, K)`` where ``K`` is the sum of
-                dimensions that are defined in each ``hyperparameter`` that composes this
-                ``tunable``.
+                dimensions from each ``hyperparameter`` that composes this ``tunable``.
 
         Returns:
             pandas.DataFrame
@@ -171,8 +166,8 @@ class Tunable:
 
         Returns:
             numpy.ndarray:
-                2D array with shape of ``(n_samples, K))`` where ``K``  is the sum of dimensions
-                that are defined in each ``hyperparameter`` that composes this ``tunable``.
+                2D array with shape of ``(n_samples, K))`` where ``K``  is the sum of
+                dimensions from each ``hyperparameter`` that composes this ``tunable``.
 
         Example:
             The example below shows a simple usage of a Tunable class which will generate 2

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -3,27 +3,36 @@
 import numpy as np
 import pandas as pd
 
+"""Package where the Tunable class is defined."""
+
 
 class Tunable:
     """Tunable class.
 
-    Collection of HyperParams that need to be tuned as a whole.
+    The Tunable class contains a collection of hyperparameters and metadata related to them, is
+    able to control this collection and work with the hyperparameters defined as a bulk.
+    This class has the same public methods as ``BaseHyperParam``. Keep in mind that a certain
+    order should be followed during the usage of this class, which is defined by ``self.names``.
+    This is the expected order of hyperparameter values that are expected to be recived by the
+    methods.
 
     Attributes:
-        hyperparams: List of hyperparameters from this hyperparam space.
+        hyperparams:
+            Dict of hyperparameters.
+        names:
+            List of names that the hyperparameters have.
     """
 
     def __init__(self, hyperparams, names=None):
         """Creates an instance of a Tunable class.
 
         Args:
-            hyperparams(dictLike):
-                Dictionary like object that contains the name and the hyperparameter asociated to
-                it.
-            names(list):
-                List of names to be used as order during inverse_transform. If this value is None,
-                the default order from the dictionary will be used. You should check ``self.names``
-                so you can give the correct order of your transformed data.
+            hyperparams (dict):
+                Dictionary object that contains the name and the hyperparameter asociated to it.
+            names (list):
+                List of names to be used as order during inverse_transform. If this value is
+                ``None``, the default order from the dictionary will be used. Be aware that
+                ``self.names`` gives the correct order for the transformed data.
         """
 
         self.hyperparams = hyperparams
@@ -37,20 +46,48 @@ class Tunable:
         """Transform one or more hyperparameter value combinations.
 
         Transform one or more hyperparameter value combinations from the original hyperparameter
-        space the normalized search space [0, 1]^K.
+        space to the normalized searc space.
 
         Args:
             values (pandas.DataFrame, pandas.Series, dict, list(dict), 2D ArrayLike):
-                Values of shape (*, len(self.hyperparameters)).
+                Values of shape (n, len(self.hyperparameters)).
 
         Returns:
-            transformed (ArrayLike):
+            numpy.ndarray:
                 2D array of shape (len(values), K)
+
+        Example:
+            The example below shows a simple usage of a Tunable class which will transform a valid
+            data from a 2D list and a ``numpy.ndarray`` is being returned.
+
+            >>> from btb.tuning.tunable import Tunable
+            >>> from btb.tuning.hyperparams.boolean import BooleanHyperParam
+            >>> from btb.tuning.hyperparams.categorical import CategoricalHyperParam
+            >>> from btb.tuning.hyperparams.numerical import IntHyperParam
+            >>> chp = CategoricalHyperParam(['cat', 'dog'])
+            >>> bhp = BooleanHyperParam()
+            >>> ihp = IntHyperParam(1, 10)
+            >>> hyperparams = {
+            ...     'chp': chp,
+            ...     'bhp': bhp,
+            ...     'ihp': ihp
+            ... }
+            >>> names = ['chp', 'bhp', 'ihp']
+            >>> tunable = Tunable(hyperparams=hyperparams, names=names)
+            >>> values = [
+            ...     ['cat', False, 10],
+            ...     ['dog', True, 1],
+            ... ]
+            >>> tunable.transform(values)
+            array([[1.  , 0.  , 0.  , 0.95],
+                   [0.  , 1.  , 1.  , 0.05]])
         """
         if isinstance(values, dict):
             values = pd.DataFrame([values])
         elif isinstance(values, list) and isinstance(values[0], dict):
             values = pd.DataFrame(values, columns=self.names)
+        elif isinstance(values, list) and not isinstance(values[0], list):
+            values = pd.DataFrame([values], columns=self.names)
         elif isinstance(values, pd.Series):
             values = values.to_frame().T
         elif not isinstance(values, pd.DataFrame):
@@ -73,10 +110,37 @@ class Tunable:
 
         Args:
             values (ArrayLike):
-                2D array of normalized values with shape (*, K).
+                2D array of normalized values with shape (n, K).
 
         Returns:
             pandas.DataFrame
+
+        Example:
+            The example below shows a simple usage of a Tunable class which will inverse transform
+            a valid data from a 2D list and a ``pandas.DataFrame`` is being returned.
+
+            >>> from btb.tuning.tunable import Tunable
+            >>> from btb.tuning.hyperparams.boolean import BooleanHyperParam
+            >>> from btb.tuning.hyperparams.categorical import CategoricalHyperParam
+            >>> from btb.tuning.hyperparams.numerical import IntHyperParam
+            >>> chp = CategoricalHyperParam(['cat', 'dog'])
+            >>> bhp = BooleanHyperParam()
+            >>> ihp = IntHyperParam(1, 10)
+            >>> hyperparams = {
+            ...     'chp': chp,
+            ...     'bhp': bhp,
+            ...     'ihp': ihp
+            ... }
+            >>> names = ['chp', 'bhp', 'ihp']
+            >>> tunable = Tunable(hyperparams=hyperparams, names=names)
+            >>> values = [
+            ...     [1, 0, 0, 0.95],
+            ...     [0, 1, 1, 0.05]
+            ... ]
+            >>> tunable.inverse_transform(values)
+               chp    bhp ihp
+            0  cat  False  10
+            1  dog   True   1
         """
 
         inverse_transform = list()
@@ -103,8 +167,30 @@ class Tunable:
                 Number of values to sample.
 
         Returns:
-            samples (ArrayLike):
+            numpy.ndarray:
                 2D array with shape of (n_samples, sum(hyperparams.K)).
+
+        Example:
+            The example below shows a simple usage of a Tunable class which will generate 2
+            samples by calling it's sample method. This will return a ``numpy.ndarray``.
+
+            >>> from btb.tuning.tunable import Tunable
+            >>> from btb.tuning.hyperparams.boolean import BooleanHyperParam
+            >>> from btb.tuning.hyperparams.categorical import CategoricalHyperParam
+            >>> from btb.tuning.hyperparams.numerical import IntHyperParam
+            >>> chp = CategoricalHyperParam(['cat', 'dog'])
+            >>> bhp = BooleanHyperParam()
+            >>> ihp = IntHyperParam(1, 10)
+            >>> hyperparams = {
+            ...     'chp': chp,
+            ...     'bhp': bhp,
+            ...     'ihp': ihp
+            ... }
+            >>> names = ['chp', 'bhp', 'ihp']
+            >>> tunable = Tunable(hyperparams=hyperparams, names=names)
+            >>> tunable.sample(2)
+            array([[0.  , 1.  , 0.  , 0.45],
+                   [1.  , 0.  , 1.  , 0.95]])
         """
         samples = list()
 

--- a/btb/tuning/tunable.py
+++ b/btb/tuning/tunable.py
@@ -9,9 +9,9 @@ import pandas as pd
 class Tunable:
     """Tunable class.
 
-    The Tunable class contains a collection of hyperparameters and metadata related to them. Is
-    able to control this collection and work with the hyperparameters defined as a bulk.
-    This class has the same public methods as ``BaseHyperParam``.
+    This class is able to control a collection of ``hyperparameters`` and work with them as a
+    bulk. The class can ``transform``, ``inverse_transform`` and ``sample`` combinations of values
+    for the ``hyperparameters`` that compose the instance.
 
     Attributes:
         hyperparams:
@@ -23,24 +23,17 @@ class Tunable:
     Args:
         hyperparams (dict):
             Dictionary object that contains the name and the hyperparameter asociated to it.
-        names (list):
-            List of names to be used as order during ``inverse_transform``. If this value is
-            ``None``, the default order from the dictionary will be used.
     """
 
-    def __init__(self, hyperparams, names=None):
+    def __init__(self, hyperparams):
         self.hyperparams = hyperparams
-
-        if names is None:
-            names = list(hyperparams)
-
-        self.names = names
+        self.names = list(hyperparams)
 
     def transform(self, values):
-        """Transform one or more hyperparameter value combinations.
+        """Transform one or more value combinations.
 
-        Transform one or more hyperparameter value combinations from the original hyperparameter
-        space to the normalized search space.
+        Transform one or more value combinations from the original hyperparameters spaces to the
+        normalized search space.
 
         Args:
             values (pandas.DataFrame, pandas.Series, dict, list(dict), 2D array-like):
@@ -49,7 +42,7 @@ class Tunable:
         Returns:
             numpy.ndarray:
                 2D array of shape ``(len(values), K)`` where ``K`` is the sum of dimensions from
-                each ``hyperparameter`` that composes this ``tunable``.
+                all the ``hyperparameters`` that compose this ``tunable``.
 
         Example:
             The example below shows a simple usage of a Tunable class which will transform a valid
@@ -66,8 +59,7 @@ class Tunable:
             ...     'bhp': bhp,
             ...     'ihp': ihp
             ... }
-            >>> names = ['chp', 'bhp', 'ihp']
-            >>> tunable = Tunable(hyperparams, names=names)
+            >>> tunable = Tunable(hyperparams)
             >>> values = [
             ...     ['cat', False, 10],
             ...     ['dog', True, 1],
@@ -101,15 +93,15 @@ class Tunable:
         return np.concatenate(transformed, axis=1)
 
     def inverse_transform(self, values):
-        """Inverse transform one or more hyperparameter value combinations.
+        """Inverse transform one or more value combinations.
 
-        Transform one or more hyperparameter values from the normalized search space
-        :math:`[0, 1]^K` to the original hyperparameter space.
+        Inverse transform one or more hyperparameter value combinations from the normalized search
+        space :math:`[0, 1]^K` to the original hyperparameter space.
 
         Args:
             values (array-like):
                 2D array of normalized values with shape ``(n, K)`` where ``K`` is the sum of
-                dimensions from each ``hyperparameter`` that composes this ``tunable``.
+                dimensions from all the ``hyperparameters`` that compose this ``tunable``.
 
         Returns:
             pandas.DataFrame
@@ -129,8 +121,7 @@ class Tunable:
             ...     'bhp': bhp,
             ...     'ihp': ihp
             ... }
-            >>> names = ['chp', 'bhp', 'ihp']
-            >>> tunable = Tunable(hyperparams, names=names)
+            >>> tunable = Tunable(hyperparams)
             >>> values = [
             ...     [1, 0, 0, 0.95],
             ...     [0, 1, 1, 0.05]
@@ -166,8 +157,8 @@ class Tunable:
 
         Returns:
             numpy.ndarray:
-                2D array with shape of ``(n_samples, K))`` where ``K``  is the sum of
-                dimensions from each ``hyperparameter`` that composes this ``tunable``.
+                2D array with shape of ``(n_samples, K)`` where ``K``  is the sum of
+                dimensions from all the ``hyperparameters`` that compose this ``tunable``.
 
         Example:
             The example below shows a simple usage of a Tunable class which will generate 2
@@ -184,8 +175,7 @@ class Tunable:
             ...     'bhp': bhp,
             ...     'ihp': ihp
             ... }
-            >>> names = ['chp', 'bhp', 'ihp']
-            >>> tunable = Tunable(hyperparams, names=names)
+            >>> tunable = Tunable(hyperparams)
             >>> tunable.sample(2)
             array([[0.  , 1.  , 0.  , 0.45],
                    [1.  , 0.  , 1.  , 0.95]])

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,10 @@ except IOError:
 
 
 install_requires = [
-    'numpy==1.17.0',
-    'scikit-learn==0.21.3',
-    'scipy==1.3.1',
-    'six==1.12.0',
-    'pandas==0.25.0'
+    'numpy>=1.17.0,<1.18.0',
+    'scikit-learn>=0.21.3,<0.22.0',
+    'scipy>=1.3.1,<1.4.0',
+    'pandas>=0.25.0,<0.26.0'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ except IOError:
 
 
 install_requires = [
-    'numpy>=1.17.0,<1.18.0',
-    'scikit-learn>=0.21.3,<0.22.0',
-    'scipy>=1.3.1,<1.4.0',
-    'pandas>=0.25.0,<0.26.0'
+    'numpy>=1.14.0,<1.18.0',
+    'scikit-learn>=0.20.0,<0.22.0',
+    'scipy>=1.0.1,<1.4.0',
+    'pandas>=0.21.0,<0.26.0'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,11 @@ except IOError:
 
 
 install_requires = [
-    'numpy==1.14.2',
-    'pandas==0.25.0',
-    'scikit-learn==0.19.1',
-    'scipy==1.0.1',
-    'six==1.0',
+    'numpy==1.17.0',
+    'scikit-learn==0.21.3',
+    'scipy==1.3.1',
+    'six==1.12.0',
+    'pandas==0.25.0'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,11 @@ except IOError:
 
 
 install_requires = [
-    'enum34>=1.1.6; python_version=="2.7"',
-    'more-itertools<6; python_version=="2.7"',  # some upstream bug
-    'numpy>=1.14.2',
-    'scikit-learn>=0.19.1',
-    'scipy>=1.0.1',
-    'six>=1.0',
+    'numpy==1.14.2',
+    'pandas==0.25.0',
+    'scikit-learn==0.19.1',
+    'scipy==1.0.1',
+    'six==1.0',
 ]
 
 

--- a/tests/tuning/hyperparams/test_base.py
+++ b/tests/tuning/hyperparams/test_base.py
@@ -48,13 +48,13 @@ class TestBaseHyperParam(TestCase):
     @patch('btb.tuning.hyperparams.base.BaseHyperParam._within_range')
     def test__within_search_space(self, mock__within_range):
         # setup
-        values = 15
+        values = np.array(15)
 
         # run
         self.instance._within_search_space(values)
 
         # assert
-        mock__within_range.assert_called_once_with(15, min=0, max=1)
+        mock__within_range.assert_called_once_with(np.array(15), min=0, max=1)
 
     @patch('btb.tuning.hyperparams.base.BaseHyperParam._within_range')
     def test__within_hyperparam_space(self, mock__within_range):

--- a/tests/tuning/test_tunable.py
+++ b/tests/tuning/test_tunable.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, call
 import numpy as np
 import pandas as pd
 
+from btb.tuning.hyperparams.categorical import CategoricalHyperParam
 from btb.tuning.tunable import Tunable
 
 
@@ -19,108 +20,203 @@ def assert_called_with_np_array(mock_calls, real_calls):
 class TestTunable(TestCase):
     """Unit test for the class ``Tunable``."""
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         """Instantiate the ``Tunable`` and it's ``Hyperparameters`` that we will be using."""
-        cls.bhp = MagicMock()
-        cls.chp = MagicMock()
-        cls.ihp = MagicMock()
+        self.bhp = MagicMock()
+        self.chp = MagicMock()
+        self.ihp = MagicMock()
 
         hyperparams = {
-            'bhp': cls.bhp,
-            'chp': cls.chp,
-            'ihp': cls.ihp,
+            'bhp': self.bhp,
+            'chp': self.chp,
+            'ihp': self.ihp,
         }
 
-        cls.instance = Tunable(hyperparams, names=['bhp', 'chp', 'ihp'])
+        self.instance = Tunable(hyperparams, names=['bhp', 'chp', 'ihp'])
 
     def test___init__(self):
         """Test that the names are being generated correctly."""
 
-        # setup
+        # assert
         expected_names = ['bhp', 'chp', 'ihp']
 
-        # assert
         assert all(name in self.instance.names for name in expected_names)
 
-    def test_transform_valid_values(self):
-        """Test transform with valid values only."""
+    def test_transform_valid_dict(self):
+        """Test transform method with a dictionary that has all the hyperparameters."""
         # setup
         self.bhp.transform.return_value = [[1]]
         self.chp.transform.return_value = [[0]]
         self.ihp.transform.return_value = [[1]]
 
-        values_dict = {'bhp': True, 'chp': 'cat', 'ihp': 1}
+        values_dict = {
+            'bhp': True,
+            'chp': 'cat',
+            'ihp': 1
+        }
+
+        # run
+        result = self.instance.transform(values_dict)
+
+        # assert
+
+        self.bhp.transform.assert_called_once_with(True)
+        self.chp.transform.assert_called_once_with('cat')
+        self.ihp.transform.assert_called_once_with(1)
+
+        np.testing.assert_array_equal(result, np.array([[1, 0, 1]]))
+
+    def test_transform_invalid_dict(self):
+        """Test transform method with a dictionary that has a missing hyperparameters."""
+        # run / assert
+        with self.assertRaises(KeyError):
+            self.instance.transform({})
+
+    def test_transform_invalid_dict_one_missing(self):
+        """Test transform method with a dictionary that has a missing hyperparameters."""
+        # run / assert
+        values = {
+            'bhp': True,
+            'chp': 'cat'
+        }
+
+        with self.assertRaises(KeyError):
+            self.instance.transform(values)
+
+    def test_transform_list_of_dicts(self):
+        """Test transform method with a list of dictionaries."""
+        # setup
+        self.bhp.transform.return_value = [[1], [0]]
+        self.chp.transform.return_value = [[0], [1]]
+        self.ihp.transform.return_value = [[1], [1]]
+
         values_list_dict = [
             {'bhp': True, 'chp': 'cat', 'ihp': 2},
             {'bhp': False, 'chp': 'cat', 'ihp': 3}
         ]
 
-        values_series = pd.Series([False, 'cat', 1], index=['bhp', 'chp', 'ihp'])
-        values_array = [[True, 'dog', 2]]
-        values_larger_array = [[True, 'dog', 2], [False, 'cat', 3]]
-
-        values_df = pd.DataFrame([{'bhp': True, 'chp': 'cat', 'ihp': 1}])
-
         # run
-        self.instance.transform(values_dict)
-        self.instance.transform(values_list_dict)
-        self.instance.transform(values_series)
-        self.instance.transform(values_array)
-        self.instance.transform(values_larger_array)
-        self.instance.transform(values_df)
+        results = self.instance.transform(values_list_dict)
 
         # assert
-        expected_call_bhp_transform = [
-            call(np.array([True])),
-            call(np.array([True, False])),
-            call(np.array([False], dtype=object)),
-            call(np.array([True])),
-            call(np.array([True, False])),
-            call(np.array([True]))]
+        assert_called_with_np_array(self.bhp.transform.call_args_list, [call([True, False])])
+        assert_called_with_np_array(self.chp.transform.call_args_list, [call(['cat', 'cat'])])
+        assert_called_with_np_array(self.ihp.transform.call_args_list, [call([2, 3])])
 
-        expected_call_chp_transform = [
-            call(np.array(['cat'])),
-            call(np.array(['cat', 'cat'])),
-            call(np.array(['cat'])),
-            call(np.array(['dog'])),
-            call(np.array(['dog', 'cat'])),
-            call(np.array(['cat'])),
-        ]
+        np.testing.assert_array_equal(results, np.array([[1, 0, 1], [0, 1, 1]]))
 
-        expected_call_ihp_transform = [
-            call(np.array([1])),
-            call(np.array([2, 3])),
-            call(np.array([1])),
-            call(np.array([2])),
-            call(np.array([2, 3])),
-            call(np.array([1])),
-        ]
-
-        assert_called_with_np_array(self.bhp.transform.call_args_list, expected_call_bhp_transform)
-        assert_called_with_np_array(self.chp.transform.call_args_list, expected_call_chp_transform)
-        assert_called_with_np_array(self.ihp.transform.call_args_list, expected_call_ihp_transform)
-
-    def test_transform_invalid_values(self):
-        """Test transform method with invalid values."""
+    def test_transform_list_of_invalid_dicts(self):
+        """Test transform method with a list of dictionaries where one of them does not have
+        the categorical value."""
 
         # setup
-        values_1 = [False, 'cat', 1]
-        values_2 = [[False, True], ['cat', 'dog'], [1, 1]]
+        self.bhp.transform.return_value = [[1], [0]]
+        # Here we create a CHP so we can raise a value error as there will be a NaN inside the
+        # pandas.DataFrame created inside that will use this data.
+        self.chp = CategoricalHyperParam(['cat', 'dog'])
+        self.ihp.transform.return_value = [[1], [1]]
+
+        values_list_dict = [
+            {'bhp': True, 'ihp': 2},
+            {'bhp': False, 'chp': 'cat', 'ihp': 3}
+        ]
 
         # run / assert
-
         with self.assertRaises(ValueError):
-            self.instance.transform(values_1)
+            self.instance.transform(values_list_dict)
 
-        with self.assertRaises(ValueError):
-            self.instance.transform(values_2)
+    def test_transform_empty_list(self):
+        """Test transform method with a empty list."""
+        # run / assert
+        with self.assertRaises(IndexError):
+            self.instance.transform([])
 
-        self.bhp.transform.assert_not_called()
-        self.chp.transform.assert_not_called()
-        self.ihp.transform.assert_not_called()
+    def test_transform_valid_pandas_series(self):
+        """Test transform method over a valid pandas series object."""
+        # setup
+        self.bhp.transform.return_value = [[1]]
+        self.chp.transform.return_value = [[0]]
+        self.ihp.transform.return_value = [[1]]
 
-    def test_inverse_transform(self):
+        values = pd.Series([False, 'cat', 1], index=['bhp', 'chp', 'ihp'])
+
+        # run
+        result = self.instance.transform(values)
+
+        # assert
+        self.bhp.transform.assert_called_once_with(False)
+        self.chp.transform.assert_called_once_with('cat')
+        self.ihp.transform.assert_called_once_with(1)
+
+        np.testing.assert_array_equal(result, np.array([[1, 0, 1]]))
+
+    def test_transform_invalid_pandas_series(self):
+        """Test transform method over a pandas series object without index."""
+        # setup
+        values = pd.Series([False, 'cat', 1])
+
+        # run
+        with self.assertRaises(KeyError):
+            self.instance.transform(values)
+
+    def test_transform_array_like_list(self):
+        """Test transform a valid array like list."""
+        # setup
+        self.bhp.transform.return_value = [[1]]
+        self.chp.transform.return_value = [[0]]
+        self.ihp.transform.return_value = [[1]]
+
+        values = [[True, 'dog', 2], [False, 'cat', 3]]
+
+        # run
+        result = self.instance.transform(values)
+
+        # assert
+        assert_called_with_np_array(
+            self.bhp.transform.call_args_list,
+            [call(np.array([True, False]))]
+        )
+        assert_called_with_np_array(
+            self.chp.transform.call_args_list,
+            [call(np.array(['dog', 'cat']))]
+        )
+        assert_called_with_np_array(
+            self.ihp.transform.call_args_list,
+            [call(np.array([2, 3]))]
+        )
+
+        np.testing.assert_array_equal(result, np.array([[1, 0, 1]]))
+
+    def test_transform_simple_list(self):
+        """Test that the method transform performs a transformation over a list with a single
+        combination of hyperparameter valid values.
+        """
+        # setup
+        self.bhp.transform.return_value = [[1]]
+        self.chp.transform.return_value = [[0]]
+        self.ihp.transform.return_value = [[1]]
+
+        values = [True, 'dog', 2]
+
+        # run
+        result = self.instance.transform(values)
+
+        # assert
+        self.bhp.transform.assert_called_once_with(True)
+        self.chp.transform.assert_called_once_with('dog')
+        self.ihp.transform.assert_called_once_with(2)
+
+        np.testing.assert_array_equal(result, np.array([[1, 0, 1]]))
+
+    def test_transform_simple_invalid_list(self):
+        """Test that the method transform does not transform a list with a single combination
+        of hyperparameter invalid values.
+        """
+        # run
+        with self.assertRaises(TypeError):
+            self.instance.transform([[True], 1, 2])
+
+    def test_inverse_transform_valid_data(self):
         """Test the inverse transform method is calling the hyperparameters."""
         # setup
         self.bhp.K = 1
@@ -149,7 +245,16 @@ class TestTunable(TestCase):
         self.bhp.inverse_transform.assert_called_once_with([1])
         self.chp.inverse_transform.assert_called_once_with([0])
         self.ihp.inverse_transform.assert_called_once_with([1])
-        pd.testing.assert_frame_equal(expected_result, result)
+        pd.testing.assert_frame_equal(result, expected_result)
+
+    def test_inverse_transform_invalid_data(self):
+        """Test the inverse transform method is calling the hyperparameters."""
+        # setup
+        values = [1, 0, 1]
+
+        # run
+        with self.assertRaises(TypeError):
+            self.instance.inverse_transform(values)
 
     def test_sample(self):
         """Test that the method sample generates data from all the ``hyperparams``"""

--- a/tests/tuning/test_tunable.py
+++ b/tests/tuning/test_tunable.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+
+from unittest import TestCase
+from unittest.mock import MagicMock, call
+
+import numpy as np
+import pandas as pd
+
+from btb.tuning.tunable import Tunable
+
+
+def assert_called_with_np_array(mock_calls, real_calls):
+    assert len(mock_calls) == len(real_calls)
+
+    for mock_call, real_call in zip(mock_calls, real_calls):
+        np.testing.assert_array_equal(mock_call[0], real_call[1])
+
+
+class TestTunable(TestCase):
+    """Unit test for the class ``Tunable``."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Instantiate the ``Tunable`` and it's ``Hyperparameters`` that we will be using."""
+        cls.bhp = MagicMock()
+        cls.chp = MagicMock()
+        cls.ihp = MagicMock()
+
+        hyperparams = {
+            'bhp': cls.bhp,
+            'chp': cls.chp,
+            'ihp': cls.ihp,
+        }
+
+        cls.instance = Tunable(hyperparams, names=['bhp', 'chp', 'ihp'])
+
+    def test___init__(self):
+        """Test that the names are being generated correctly."""
+
+        # setup
+        expected_names = ['bhp', 'chp', 'ihp']
+
+        # assert
+        assert all(name in self.instance.names for name in expected_names)
+
+    def test_transform_valid_values(self):
+        """Test transform with valid values only."""
+        # setup
+        self.bhp.transform.return_value = [[1]]
+        self.chp.transform.return_value = [[0]]
+        self.ihp.transform.return_value = [[1]]
+
+        values_dict = {'bhp': True, 'chp': 'cat', 'ihp': 1}
+        values_list_dict = [
+            {'bhp': True, 'chp': 'cat', 'ihp': 2},
+            {'bhp': False, 'chp': 'cat', 'ihp': 3}
+        ]
+
+        values_series = pd.Series([False, 'cat', 1], index=['bhp', 'chp', 'ihp'])
+        values_array = [[True, 'dog', 2]]
+        values_larger_array = [[True, 'dog', 2], [False, 'cat', 3]]
+
+        values_df = pd.DataFrame([{'bhp': True, 'chp': 'cat', 'ihp': 1}])
+
+        # run
+        self.instance.transform(values_dict)
+        self.instance.transform(values_list_dict)
+        self.instance.transform(values_series)
+        self.instance.transform(values_array)
+        self.instance.transform(values_larger_array)
+        self.instance.transform(values_df)
+
+        # assert
+        expected_call_bhp_transform = [
+            call(np.array([True])),
+            call(np.array([True, False])),
+            call(np.array([False], dtype=object)),
+            call(np.array([True])),
+            call(np.array([True, False])),
+            call(np.array([True]))]
+
+        expected_call_chp_transform = [
+            call(np.array(['cat'])),
+            call(np.array(['cat', 'cat'])),
+            call(np.array(['cat'])),
+            call(np.array(['dog'])),
+            call(np.array(['dog', 'cat'])),
+            call(np.array(['cat'])),
+        ]
+
+        expected_call_ihp_transform = [
+            call(np.array([1])),
+            call(np.array([2, 3])),
+            call(np.array([1])),
+            call(np.array([2])),
+            call(np.array([2, 3])),
+            call(np.array([1])),
+        ]
+
+        assert_called_with_np_array(self.bhp.transform.call_args_list, expected_call_bhp_transform)
+        assert_called_with_np_array(self.chp.transform.call_args_list, expected_call_chp_transform)
+        assert_called_with_np_array(self.ihp.transform.call_args_list, expected_call_ihp_transform)
+
+    def test_transform_invalid_values(self):
+        """Test transform method with invalid values."""
+
+        # setup
+        values_1 = [False, 'cat', 1]
+        values_2 = [[False, True], ['cat', 'dog'], [1, 1]]
+
+        # run / assert
+
+        with self.assertRaises(ValueError):
+            self.instance.transform(values_1)
+
+        with self.assertRaises(ValueError):
+            self.instance.transform(values_2)
+
+        self.bhp.transform.assert_not_called()
+        self.chp.transform.assert_not_called()
+        self.ihp.transform.assert_not_called()
+
+    def test_inverse_transform(self):
+        """Test the inverse transform method is calling the hyperparameters."""
+        # setup
+        self.bhp.K = 1
+        self.chp.K = 1
+        self.ihp.K = 1
+
+        self.bhp.inverse_transform.return_value = [[True]]
+        self.chp.inverse_transform.return_value = [['cat']]
+        self.ihp.inverse_transform.return_value = [[1]]
+
+        values = [[1, 0, 1]]
+
+        # run
+        result = self.instance.inverse_transform(values)
+
+        # assert
+        expected_result = pd.DataFrame(
+            {
+                'bhp': [True],
+                'chp': ['cat'],
+                'ihp': [1]
+            },
+            dtype=object
+        )
+
+        self.bhp.inverse_transform.assert_called_once_with([1])
+        self.chp.inverse_transform.assert_called_once_with([0])
+        self.ihp.inverse_transform.assert_called_once_with([1])
+        pd.testing.assert_frame_equal(expected_result, result)
+
+    def test_sample(self):
+        """Test that the method sample generates data from all the ``hyperparams``"""
+
+        # setup
+        self.bhp.sample.return_value = [[1]]
+        self.chp.sample.return_value = [[1, 1]]
+        self.ihp.sample.return_value = [[1]]
+
+        # run
+        result = self.instance.sample(1)
+
+        # assert
+        expected_result = [[1, 1, 1, 1]]
+
+        self.bhp.sample.assert_called_once_with(1)
+        self.chp.sample.assert_called_once_with(1)
+        self.ihp.sample.assert_called_once_with(1)
+        assert (result == expected_result).all()

--- a/tests/tuning/test_tunable.py
+++ b/tests/tuning/test_tunable.py
@@ -20,11 +20,14 @@ def assert_called_with_np_array(mock_calls, real_calls):
 class TestTunable(TestCase):
     """Unit test for the class ``Tunable``."""
 
-    def setUp(self):
+    @patch('btb.tuning.tunable.list')
+    def setUp(self, list_mock):
         """Instantiate the ``Tunable`` and it's ``Hyperparameters`` that we will be using."""
         self.bhp = MagicMock()
         self.chp = MagicMock()
         self.ihp = MagicMock()
+
+        list_mock.return_value = ['bhp', 'chp', 'ihp']
 
         hyperparams = {
             'bhp': self.bhp,
@@ -32,31 +35,12 @@ class TestTunable(TestCase):
             'ihp': self.ihp,
         }
 
-        self.instance = Tunable(hyperparams, names=['bhp', 'chp', 'ihp'])
-
-    @patch('btb.tuning.tunable.list')
-    def test___init__not_given_names(self, list_mock):
-        """Test the init method without giving names to it."""
-
-        # A mock for list() is being used as python 3.5 does not maintain the order.
-        # setup
-        list_mock.return_value = ['a', 'b']
-
-        # run
-        self.instance = Tunable({'a': 1, 'b': 2})
-
-        # assert
-        list_mock.assert_called_once_with({'a': 1, 'b': 2})
-        assert self.instance.names == ['a', 'b']
+        self.instance = Tunable(hyperparams)
 
     def test___init__with_given_names(self):
         """Test that the names are being generated correctly."""
-
-        # run
-        instance = Tunable({}, names=['bhp', 'chp', 'ihp'])
-
         # assert
-        assert instance.names == ['bhp', 'chp', 'ihp']
+        assert self.instance.names == ['bhp', 'chp', 'ihp']
 
     def test_transform_valid_dict(self):
         """Test transform method with a dictionary that has all the hyperparameters."""

--- a/tests/tuning/test_tunable.py
+++ b/tests/tuning/test_tunable.py
@@ -298,17 +298,17 @@ class TestTunable(TestCase):
 
         # setup
         # Values have been changed to ensure that each one of them is being called.
-        self.bhp.sample.return_value = [[True]]
-        self.chp.sample.return_value = [['dog']]
-        self.ihp.sample.return_value = [[4]]
+        self.bhp.sample.return_value = [['a']]
+        self.chp.sample.return_value = [['b']]
+        self.ihp.sample.return_value = [['c']]
 
         # run
         result = self.instance.sample(1)
 
         # assert
-        expected_result = [[True, 'dog', 4]]
+        expected_result = np.array([['a', 'b', 'c']])
 
+        assert set(result.flat) == set(expected_result.flat)
         self.bhp.sample.assert_called_once_with(1)
         self.chp.sample.assert_called_once_with(1)
         self.ihp.sample.assert_called_once_with(1)
-        assert (result == expected_result).all()


### PR DESCRIPTION
Implemented a `Tunable` class that is able to control a bulk of hyperparameters with the same public methods as `BaseHyperParam`.
- Implement `Tunable class`
- Implment unit tests for this class.
- Fix hyperparameters bugs / issues with `dtypes`.
- Update docstrings.

Resolve #133 