### PR TITLE
Tuner has no `scores` attribute until `record` is run once

### DIFF
--- a/btb/tuning/tuners/base.py
+++ b/btb/tuning/tuners/base.py
@@ -28,8 +28,11 @@ class BaseTuner:
         trials (numpy.ndarray):
             A ``numpy.ndarray`` with shape ``(n, self.tunable.dimensions)`` where ``n`` is the
             number of trials recorded.
-        scores (numpy.ndarray):
+        raw_scores (numpy.ndarray):
             A ``numpy.ndarray`` with shape ``(n, 1)`` where ``n`` is the number of scores recorded.
+        scores (numpy.ndarray):
+            A ``numpy.ndarray`` with shape ``(n, 1)`` where ``n`` is the number of normalized
+            scores recorded.
 
     Args:
         tunable (btb.tuning.tunable.Tunable):
@@ -44,6 +47,7 @@ class BaseTuner:
         self.trials = np.empty((0, self.tunable.dimensions), dtype=np.float)
         self._trials_set = set()
         self.raw_scores = np.empty((0, 1), dtype=np.float)
+        self.scores = np.empty((0, 1), dtype=np.float)
         self.maximize = maximize
         LOGGER.debug(
             ('Creating %s instance with %s hyperparameters and carinality %s.'),

--- a/tests/tuning/tuners/test_base.py
+++ b/tests/tuning/tuners/test_base.py
@@ -23,6 +23,7 @@ class TestBaseTuner(TestCase):
         assert instance.tunable is tunable
         assert isinstance(instance.trials, np.ndarray)
         assert isinstance(instance.raw_scores, np.ndarray)
+        assert isinstance(instance.scores, np.ndarray)
         assert isinstance(instance._trials_set, set)
         assert isinstance(instance.maximize, bool)
 
@@ -43,6 +44,7 @@ class TestBaseTuner(TestCase):
         assert isinstance(instance.tunable, MagicMock)
         assert isinstance(instance.trials, np.ndarray)
         assert isinstance(instance.raw_scores, np.ndarray)
+        assert isinstance(instance.scores, np.ndarray)
         assert isinstance(instance._trials_set, set)
         assert isinstance(instance.maximize, bool)
 


### PR DESCRIPTION
Create `scores` as empty array during instantiation of a Tuner.

Resolve #170 