### PR TITLE
Issue 166 wrong error raised by session

### DIFF
--- a/btb/__init__.py
+++ b/btb/__init__.py
@@ -2,6 +2,9 @@
 
 """Top-level package for BTB."""
 
+from btb.session import BTBSession
+
 __author__ = """MIT Data To AI Lab"""
 __email__ = 'dailabmit@gmail.com'
 __version__ = '0.3.6.dev0'
+__all__ = ('BTBSession', )

--- a/btb/session.py
+++ b/btb/session.py
@@ -178,10 +178,10 @@ class BTBSession:
             StopTuning:
                 If the ``BTBSession`` has run out of proposals to generate.
         """
-        if not self._tunables:
-            raise StopTuning('There are no proposals left to try.')
+        if not self._tunable_names:
+            raise StopTuning('There are no tunables left to try.')
 
-        if len(self._normalized_scores) < len(self._tunable_names):
+        if len(self._tuners) < len(self._tunable_names):
             tunable_name = self._tunable_names[len(self._normalized_scores)]
             tunable = self._tunables[tunable_name]
 
@@ -259,6 +259,8 @@ class BTBSession:
             self.handle_error(tunable_name)
         else:
             normalized = self._normalize(score)
+            self._normalized_scores[tunable_name].append(normalized)
+
             if normalized > self._best_normalized:
                 LOGGER.info('New optimal found: %s - %s', tunable_name, score)
                 self.best_proposal = proposal
@@ -267,9 +269,8 @@ class BTBSession:
             try:
                 tuner = self._tuners[tunable_name]
                 tuner.record(config, normalized)
-                self._normalized_scores[tunable_name].append(normalized)
             except Exception:
-                LOGGER.exception('Could not record score to tuner.')
+                LOGGER.exception('Could not record configuration and score to tuner.')
 
     def run(self, iterations=None):
         """Run the selection and tuning loop for the given number of iterations.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ development_requires = [
     # docs
     'autodocsumm>=0.1.10',
     'm2r>=0.2.0',
-    'Sphinx>=1.7.1',
+    'Sphinx>=1.7.1,<2.4',
     'sphinx_rtd_theme>=0.2.4',
 
     # style check

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -115,7 +115,7 @@ class TestBTBSession(TestCase):
     def test_propose_no_tunables(self):
         # setup
         instance = MagicMock(spec_set=BTBSession)
-        instance._tunables = None
+        instance._tunable_names = None
 
         # run
         with self.assertRaises(StopTuning):


### PR DESCRIPTION
- Fixed error that when no tunables are left it kept trying to propose which was leading to a `ValueError` raise.
- Added `BTBSession` to `btb` so you can now import it directly `from btb import BTBSession`.
- Cap sphinx version below `2.4` as with a new release the docs are filing because of the `m2r` plugin that we use for `.md` files until a fix is released.

Resolve #166 