### PR TITLE
Issue 182 integrate hyperopt with benchmarking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,6 @@ install: clean-build clean-pyc ## install the package to the active Python's sit
 install-examples: clean-build clean-pyc ## install the package and dependencies to run the examples
 	pip install .[examples]
 
-.PHONY: install-benchmark-additionals
-install-benchmark-additionals: clean-build clean-pyc ## install the package and dependencies to run the complete benchmark with other libraries
-	pip install .[benchmark]
-
 .PHONY: install-test
 install-test: clean-build clean-pyc ## install the package and test dependencies
 	pip install .[test]

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ install: clean-build clean-pyc ## install the package to the active Python's sit
 install-examples: clean-build clean-pyc ## install the package and dependencies to run the examples
 	pip install .[examples]
 
+.PHONY: install-benchmark-additionals
+install-benchmark-additionals: clean-build clean-pyc ## install the package and dependencies to run the complete benchmark with other libraries
+	pip install .[benchmark]
+
 .PHONY: install-test
 install-test: clean-build clean-pyc ## install the package and test dependencies
 	pip install .[test]

--- a/btb/benchmark/__init__.py
+++ b/btb/benchmark/__init__.py
@@ -4,8 +4,6 @@ import logging
 import pandas as pd
 
 from btb.benchmark.challenges import MATH_CHALLENGES, ML_CHALLENGES
-from btb.benchmark.challenges.atmchallenge import ATMChallenge  # noqa: F401
-from btb.benchmark.tuners import get_all_tuning_functions  # noqa: F401
 
 DEFAULT_CHALLENGES = MATH_CHALLENGES + ML_CHALLENGES
 LOGGER = logging.getLogger(__name__)

--- a/btb/benchmark/__init__.py
+++ b/btb/benchmark/__init__.py
@@ -32,9 +32,13 @@ def evaluate_candidate(name, candidate, challenges, iterations):
         except Exception as ex:
             LOGGER.warn(
                 'Could not score candidate %s with challenge %s, error: %s', name, challenge, ex)
+            result = {
+                'challenge': str(challenge),
+                'candidate': name,
+                'score': None,
+            }
 
-        if result:
-            candidate_result.append(result)
+        candidate_result.append(result)
 
     return candidate_result
 
@@ -94,8 +98,7 @@ def benchmark(candidates, challenges=None, iterations=1000):
 
         result = evaluate_candidate(name, candidate, challenges, iterations)
 
-        if result:
-            results.extend(result)
+        results.extend(result)
 
     df = pd.DataFrame.from_records(results)
     df = df.pivot(index='candidate', columns='challenge', values='score')

--- a/btb/benchmark/tuners/__init__.py
+++ b/btb/benchmark/tuners/__init__.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from btb.benchmark.tuners.btb import make_btb_tuning_function
+from btb.benchmark.tuners.hyperopt import hyperopt_tuning_function
 from btb.tuning.tuners import GPEiTuner, GPTuner, UniformTuner
 
 
 def get_all_tuning_functions():
     """Return all the tuning functions ready to use with benchmark."""
     return {
-        'GPTuner()': make_btb_tuning_function(GPTuner),
-        'GPEiTuner()': make_btb_tuning_function(GPEiTuner),
-        'UniformTuner()': make_btb_tuning_function(UniformTuner),
+        'GPTuner': make_btb_tuning_function(GPTuner),
+        'GPEiTuner': make_btb_tuning_function(GPEiTuner),
+        'UniformTuner': make_btb_tuning_function(UniformTuner),
+        'HyperOpt': hyperopt_tuning_function,
     }

--- a/btb/benchmark/tuners/__init__.py
+++ b/btb/benchmark/tuners/__init__.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 
+from hyperopt import rand, tpe
+
 from btb.benchmark.tuners.btb import make_btb_tuning_function
-from btb.benchmark.tuners.hyperopt import hyperopt_tuning_function
+from btb.benchmark.tuners.hyperopt import make_hyperopt_tuning_function
 from btb.tuning.tuners import GPEiTuner, GPTuner, UniformTuner
 
 
 def get_all_tuning_functions():
     """Return all the tuning functions ready to use with benchmark."""
     return {
-        'GPTuner': make_btb_tuning_function(GPTuner),
-        'GPEiTuner': make_btb_tuning_function(GPEiTuner),
-        'UniformTuner': make_btb_tuning_function(UniformTuner),
-        'HyperOpt': hyperopt_tuning_function,
+        'BTB.GPTuner': make_btb_tuning_function(GPTuner),
+        'BTB.GPEiTuner': make_btb_tuning_function(GPEiTuner),
+        'BTB.UniformTuner': make_btb_tuning_function(UniformTuner),
+        'HyperOpt.tpe.suggest': make_hyperopt_tuning_function(tpe.suggest),
+        'HyperOpt.rand.suggest': make_hyperopt_tuning_function(rand.suggest),
     }

--- a/btb/benchmark/tuners/hyperopt.py
+++ b/btb/benchmark/tuners/hyperopt.py
@@ -1,0 +1,57 @@
+from hyperopt import Trials, fmin, hp, tpe
+
+
+def search_space_from_dict(dict_hyperparams):
+    hyperparams = {}
+
+    if not isinstance(dict_hyperparams, dict):
+        raise TypeError('Hyperparams must be a dictionary.')
+
+    for name, hyperparam in dict_hyperparams.items():
+        hp_type = hyperparam['type']
+
+        if hp_type == 'int':
+            hp_range = hyperparam.get('range') or hyperparam.get('values')
+            hp_min = min(hp_range) if hp_range else None
+            hp_max = max(hp_range) if hp_range else None
+            hp_instance = hp.uniformint(name, hp_min, hp_max)
+
+        elif hp_type == 'float':
+            hp_range = hyperparam.get('range') or hyperparam.get('values')
+            hp_min = min(hp_range)
+            hp_max = max(hp_range)
+            hp_instance = hp.uniform(name, hp_min, hp_max)
+
+        elif hp_type == 'bool':
+            hp_instance = hp.choice(name, [True, False])
+
+        elif hp_type == 'str':
+            hp_choices = hyperparam.get('range') or hyperparam.get('values')
+            hp_instance = hp.choice(name, hp_choices)
+
+        hyperparams[name] = hp_instance
+
+    return hyperparams
+
+
+def sanitize_scoring_function(scoring_function):
+    def sanitized(args):
+        return -scoring_function(**args)
+
+    return sanitized
+
+
+def hyperopt_tuning_function(scoring_function, tunable_hyperparameters, iterations):
+
+    # convert scoring to minimize
+    sanitized_scorer = sanitize_scoring_function(scoring_function)
+
+    search_space = search_space_from_dict(tunable_hyperparameters)
+    trials = Trials()
+
+    fmin(sanitized_scorer, search_space, algo=tpe.suggest, max_evals=iterations, trials=trials)
+
+    # normalize best score to match other tuners
+    best_score = -1 * trials.best_trial['result']['loss']
+
+    return best_score

--- a/btb/benchmark/tuners/hyperopt.py
+++ b/btb/benchmark/tuners/hyperopt.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from hyperopt import Trials, fmin, hp, tpe
 
 

--- a/btb/benchmark/tuners/hyperopt.py
+++ b/btb/benchmark/tuners/hyperopt.py
@@ -37,13 +37,13 @@ def search_space_from_dict(dict_hyperparams):
 
 
 def make_minimize_function(scoring_function):
-    """Convert scoring function to minimize the score.
+    """Create a minimize function.
 
-    As ``BTB`` works with maximization, we have created all our challenges to ``maximize`` the
-    score and ``HyperOpt`` works with minimization only.
+    Given a maximization ``scoring_function`` convert it to minimize in order to work with
+    ``hyperopt``, as ``benchmark`` works with ``maximization``.
 
-    Also ``hyperopt`` params are being passed as an python ``dict`` and we adapt those to be
-    passed as ``kwargs``.
+    Also ``hyperopt`` params are being passed as a python ``dict``, we pass those as ``kwargs``
+    to the ``scoring_function``.
     """
     def minimized_function(params):
         return -scoring_function(**params)
@@ -52,11 +52,14 @@ def make_minimize_function(scoring_function):
 
 
 def make_hyperopt_tuning_function(algo):
-    """Create a hyperopt minimize tuning function.
+    """Create a tuning function that uses ``HyperOpt``.
+
+    With a given suggesting algorithm from the library ``HyperOpt``, create a tuning
+    function that maximize the score, using ``fmin``.
 
     Args:
         algo (hyperopt.algo):
-            Search Hyperopt Algorithm to be used with ``fmin`` function.
+            Search / Suggest ``HyperOpt`` algorithm to be used with ``fmin`` function.
     """
     def hyperopt_tuning_function(scoring_function, tunable_hyperparameters, iterations):
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     extras_require={
         'examples': examples_require,
         'benchmark': benchmark_require,
-        'test': tests_require,
+        'test': tests_require + benchmark_require,
         'dev': development_requires + tests_require + benchmark_require,
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,6 @@ install_requires = [
     'tqdm>=4.36.1,<4.50.0',
 ]
 
-benchmark_require = [
-    'hyperopt>=0.2.3,<3',
-    'tabulate>=0.8.3,<0.9',
-]
-
 
 examples_require = [
     'jupyter>=1.0.0',
@@ -47,6 +42,8 @@ examples_require = [
 tests_require = [
     'pytest>=3.4.2',
     'pytest-cov>=2.6.0',
+    'hyperopt>=0.2.3,<3',
+    'tabulate>=0.8.3,<0.9',
 ]
 
 
@@ -102,9 +99,8 @@ setup(
     description='Bayesian Tuning and Bandits',
     extras_require={
         'examples': examples_require,
-        'benchmark': benchmark_require,
-        'test': tests_require + benchmark_require,
-        'dev': development_requires + tests_require + benchmark_require,
+        'test': tests_require,
+        'dev': development_requires + tests_require,
     },
     include_package_data=True,
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         'examples': examples_require,
         'benchmark': benchmark_require,
         'test': tests_require,
-        'dev': development_requires + tests_require,
+        'dev': development_requires + tests_require + benchmark_require,
     },
     include_package_data=True,
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ except IOError:
 
 
 install_requires = [
-    'tabulate>=0.8.3,<0.9',
     'docutils>=0.10,<0.16',
     'boto3>=1.9.18,<1.10',
     'numpy>=1.14.0,<1.18.0',
@@ -31,6 +30,11 @@ install_requires = [
     'scipy>=1.0.1,<1.4.0',
     'pandas>=0.21.0,<0.26.0',
     'tqdm>=4.36.1,<4.50.0',
+]
+
+benchmark_require = [
+    'hyperopt>=0.2.3,<3',
+    'tabulate>=0.8.3,<0.9',
 ]
 
 
@@ -98,6 +102,7 @@ setup(
     description='Bayesian Tuning and Bandits',
     extras_require={
         'examples': examples_require,
+        'benchmark': benchmark_require,
         'test': tests_require,
         'dev': development_requires + tests_require,
     },

--- a/tests/benchmark/tuners/test_hyperopt.py
+++ b/tests/benchmark/tuners/test_hyperopt.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import call, patch
+
+import pytest
+from hyperopt import tpe
+
+from btb.benchmark.tuners.hyperopt import (
+    hyperopt_tuning_function, sanitize_scoring_function, search_space_from_dict)
+
+
+def test_search_space_from_dict_not_dict():
+    """Test case for method."""
+    # setup
+    hyperparams = list()
+
+    # run
+    with pytest.raises(TypeError):
+        search_space_from_dict(hyperparams)
+
+
+@patch('btb.benchmark.tuners.hyperopt.hp')
+def test_search_space_from_dict(mock_hyperopt_hp):
+    # setup
+    mock_hyperopt_hp.uniform.return_value = 'float_hyperparam'
+    mock_hyperopt_hp.uniformint.return_value = 'int_hyperparam'
+    mock_hyperopt_hp.choice.side_effect = ['choice_hyperparam', 'bool_hyperparam']
+
+    dict_hyperparams = {
+        'int': {
+            'type': 'int',
+            'range': [1, 2],
+        },
+        'float': {
+            'type': 'float',
+            'range': [0, 1],
+        },
+        'cat': {
+            'type': 'str',
+            'range': ['a', 'b'],
+        },
+        'bool': {
+            'type': 'bool',
+        },
+    }
+
+    # run
+    res = search_space_from_dict(dict_hyperparams)
+
+    # assert
+    expected_res = {
+        'int': 'int_hyperparam',
+        'float': 'float_hyperparam',
+        'cat': 'choice_hyperparam',
+        'bool': 'bool_hyperparam',
+    }
+
+    expected_call_choice = [call('cat', ['a', 'b']), call('bool', [True, False])]
+    assert res == expected_res
+
+    mock_hyperopt_hp.uniformint.assert_called_once_with('int', 1, 2)
+    mock_hyperopt_hp.uniform.assert_called_once_with('float', 0, 1)
+    assert mock_hyperopt_hp.choice.call_args_list == expected_call_choice
+
+
+def test_sanitize_scoring_function():
+    # setup
+    def scoring_function(a):
+        return a
+
+    # run
+    res_func = sanitize_scoring_function(scoring_function)
+    result = res_func({'a': 1})
+
+    # assert
+    result == -1
+
+
+@patch('btb.benchmark.tuners.hyperopt.fmin')
+@patch('btb.benchmark.tuners.hyperopt.Trials')
+@patch('btb.benchmark.tuners.hyperopt.search_space_from_dict')
+@patch('btb.benchmark.tuners.hyperopt.sanitize_scoring_function')
+def test_hyperopt_tuning_function(mock_sanitize, mock_ss_from_dict, mock_trials, mock_fmin):
+    # setup
+    mock_sanitize.return_value = 'sanitized'
+    mock_ss_from_dict.return_value = 'search_space'
+    mock_trials.return_value.best_trial = {'result': {'loss': -1}}
+
+    # run
+    result = hyperopt_tuning_function('test_scoring_func', 'tunable_hps', 10)
+
+    # assert
+    assert result == 1
+
+    mock_sanitize.assert_called_once_with('test_scoring_func')
+    mock_ss_from_dict.assert_called_once_with('tunable_hps')
+    mock_trials.assert_called_once_with()
+
+    mock_fmin.assert_called_once_with(
+        'sanitized',
+        'search_space',
+        algo=tpe.suggest,
+        max_evals=10,
+        trials=mock_trials.return_value
+    )

--- a/tests/benchmark/tuners/test_hyperopt.py
+++ b/tests/benchmark/tuners/test_hyperopt.py
@@ -3,10 +3,8 @@
 from unittest.mock import call, patch
 
 import pytest
-from hyperopt import tpe
 
-from btb.benchmark.tuners.hyperopt import (
-    hyperopt_tuning_function, sanitize_scoring_function, search_space_from_dict)
+from btb.benchmark.tuners.hyperopt import make_minimize_function, search_space_from_dict
 
 
 def test_search_space_from_dict_not_dict():
@@ -24,9 +22,9 @@ def test_search_space_from_dict(mock_hyperopt_hp):
     # setup
     mock_hyperopt_hp.uniform.return_value = 'float_hyperparam'
     mock_hyperopt_hp.uniformint.return_value = 'int_hyperparam'
-    mock_hyperopt_hp.choice.side_effect = ['choice_hyperparam', 'bool_hyperparam']
+    mock_hyperopt_hp.choice.side_effect = ('choice_hyperparam', 'bool_hyperparam')
 
-    dict_hyperparams = {
+    dict_hyperparams_cat = {
         'int': {
             'type': 'int',
             'range': [1, 2],
@@ -38,68 +36,47 @@ def test_search_space_from_dict(mock_hyperopt_hp):
         'cat': {
             'type': 'str',
             'range': ['a', 'b'],
-        },
+        }
+    }
+
+    dict_hyperparams_bool = {
         'bool': {
             'type': 'bool',
-        },
+        }
     }
 
     # run
-    res = search_space_from_dict(dict_hyperparams)
+    res_cat = search_space_from_dict(dict_hyperparams_cat)
+    res_bool = search_space_from_dict(dict_hyperparams_bool)
 
     # assert
-    expected_res = {
+    expected_res_cat = {
         'int': 'int_hyperparam',
         'float': 'float_hyperparam',
         'cat': 'choice_hyperparam',
+    }
+    expected_res_bool = {
         'bool': 'bool_hyperparam',
     }
 
     expected_call_choice = [call('cat', ['a', 'b']), call('bool', [True, False])]
-    assert res == expected_res
+
+    assert res_cat == expected_res_cat
+    assert res_bool == expected_res_bool
 
     mock_hyperopt_hp.uniformint.assert_called_once_with('int', 1, 2)
     mock_hyperopt_hp.uniform.assert_called_once_with('float', 0, 1)
     assert mock_hyperopt_hp.choice.call_args_list == expected_call_choice
 
 
-def test_sanitize_scoring_function():
+def test_make_minimize_function():
     # setup
     def scoring_function(a):
         return a
 
     # run
-    res_func = sanitize_scoring_function(scoring_function)
+    res_func = make_minimize_function(scoring_function)
     result = res_func({'a': 1})
 
     # assert
     result == -1
-
-
-@patch('btb.benchmark.tuners.hyperopt.fmin')
-@patch('btb.benchmark.tuners.hyperopt.Trials')
-@patch('btb.benchmark.tuners.hyperopt.search_space_from_dict')
-@patch('btb.benchmark.tuners.hyperopt.sanitize_scoring_function')
-def test_hyperopt_tuning_function(mock_sanitize, mock_ss_from_dict, mock_trials, mock_fmin):
-    # setup
-    mock_sanitize.return_value = 'sanitized'
-    mock_ss_from_dict.return_value = 'search_space'
-    mock_trials.return_value.best_trial = {'result': {'loss': -1}}
-
-    # run
-    result = hyperopt_tuning_function('test_scoring_func', 'tunable_hps', 10)
-
-    # assert
-    assert result == 1
-
-    mock_sanitize.assert_called_once_with('test_scoring_func')
-    mock_ss_from_dict.assert_called_once_with('tunable_hps')
-    mock_trials.assert_called_once_with()
-
-    mock_fmin.assert_called_once_with(
-        'sanitized',
-        'search_space',
-        algo=tpe.suggest,
-        max_evals=10,
-        trials=mock_trials.return_value
-    )

--- a/tests/run_benchmark.py
+++ b/tests/run_benchmark.py
@@ -6,7 +6,9 @@ from datetime import datetime
 
 import tabulate
 
-from btb.benchmark import DEFAULT_CHALLENGES, ATMChallenge, benchmark, get_all_tuning_functions
+from btb.benchmark import DEFAULT_CHALLENGES, benchmark
+from btb.benchmark.challenges import ATMChallenge
+from btb.benchmark.tuners import get_all_tuning_functions
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Fix `tests/run_benchmark.py` to run by default with all the challenges and removed `-m` argument.
- Fix `tests/run_benchmark.py` to use `sample` instead of `choices`.
- Integrate `hyperopt` with `btb.benchmark`.

Resolve #182 