### PR TITLE
Issue 184 integrate benchmark with dask

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,6 @@ install: clean-build clean-pyc ## install the package to the active Python's sit
 install-examples: clean-build clean-pyc ## install the package and dependencies to run the examples
 	pip install .[examples]
 
-.PHONY: install-benchmark-additionals
-install-benchmark-additionals: clean-build clean-pyc ## install the package and dependencies to run the complete benchmark with other libraries
-	pip install .[benchmark]
-
 .PHONY: install-test
 install-test: clean-build clean-pyc ## install the package and test dependencies
 	pip install .[test]

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ install: clean-build clean-pyc ## install the package to the active Python's sit
 install-examples: clean-build clean-pyc ## install the package and dependencies to run the examples
 	pip install .[examples]
 
+.PHONY: install-benchmark-additionals
+install-benchmark-additionals: clean-build clean-pyc ## install the package and dependencies to run the complete benchmark with other libraries
+	pip install .[benchmark]
+
 .PHONY: install-test
 install-test: clean-build clean-pyc ## install the package and test dependencies
 	pip install .[test]

--- a/btb/benchmark/__init__.py
+++ b/btb/benchmark/__init__.py
@@ -32,9 +32,13 @@ def evaluate_candidate(name, candidate, challenges, iterations):
         except Exception as ex:
             LOGGER.warn(
                 'Could not score candidate %s with challenge %s, error: %s', name, challenge, ex)
+            result = {
+                'challenge': str(challenge),
+                'candidate': name,
+                'score': None,
+            }
 
-        if result:
-            candidate_result.append(result)
+        candidate_result.append(result)
 
     return candidate_result
 
@@ -94,8 +98,7 @@ def benchmark(candidates, challenges=None, iterations=1000):
 
         result = evaluate_candidate(name, candidate, challenges, iterations)
 
-        if result:
-            results.extend(result)
+        results.extend(result)
 
     df = pd.DataFrame.from_records(results)
     df = df.pivot(index='candidate', columns='challenge', values='score')

--- a/btb/benchmark/__init__.py
+++ b/btb/benchmark/__init__.py
@@ -1,14 +1,39 @@
 # -*- coding: utf-8 -*-
+import inspect
 import logging
 
+import dask
 import pandas as pd
 
 from btb.benchmark.challenges import MATH_CHALLENGES, ML_CHALLENGES
-from btb.benchmark.challenges.atmchallenge import ATMChallenge  # noqa: F401
-from btb.benchmark.tuners import get_all_tuning_functions  # noqa: F401
 
 DEFAULT_CHALLENGES = MATH_CHALLENGES + ML_CHALLENGES
 LOGGER = logging.getLogger(__name__)
+
+
+@dask.delayed
+def _evaluate_candidate(name, candidate, challenge, iterations):
+    tunable_hyperparameters = challenge.get_tunable_hyperparameters()
+    LOGGER.info('Evaluating candidate %s on challenge %s for %s iterations',
+                name, challenge, iterations)
+    try:
+        score = candidate(challenge.evaluate, tunable_hyperparameters, iterations)
+        result = {
+            'challenge': str(challenge),
+            'candidate': name,
+            'score': score,
+        }
+
+    except Exception as ex:
+        LOGGER.warn(
+            'Could not score candidate %s with challenge %s, error: %s', name, challenge, ex)
+        result = {
+            'challenge': str(challenge),
+            'candidate': name,
+            'score': None,
+        }
+
+    return result
 
 
 def evaluate_candidate(name, candidate, challenges, iterations):
@@ -18,27 +43,14 @@ def evaluate_candidate(name, candidate, challenges, iterations):
         challenges = [challenges]
 
     for challenge in challenges:
-        tunable_hyperparameters = challenge.get_tunable_hyperparameters()
-        LOGGER.info('Evaluating candidate %s on challenge %s for %s iterations',
-                    name, challenge, iterations)
-        try:
-            score = candidate(challenge.evaluate, tunable_hyperparameters, iterations)
-            result = {
-                'challenge': str(challenge),
-                'candidate': name,
-                'score': score,
-            }
+        if inspect.isclass(challenge):
+            try:
+                challenge = challenge()
+            except Exception as ex:
+                LOGGER.warn('Could not instantiate candidate %s', name, str(challenge), ex)
+                next
 
-        except Exception as ex:
-            LOGGER.warn(
-                'Could not score candidate %s with challenge %s, error: %s', name, challenge, ex)
-            result = {
-                'challenge': str(challenge),
-                'candidate': name,
-                'score': None,
-            }
-
-        candidate_result.append(result)
+        candidate_result.append(_evaluate_candidate(name, candidate, challenge, iterations))
 
     return candidate_result
 
@@ -100,8 +112,10 @@ def benchmark(candidates, challenges=None, iterations=1000):
 
         results.extend(result)
 
+    results = [result for result in dask.compute(*results)]
+
     df = pd.DataFrame.from_records(results)
-    df = df.pivot(index='candidate', columns='challenge', values='score')
+    df = df.pivot(index='challenge', columns='candidate', values='score')
 
     del df.columns.name
     del df.index.name

--- a/btb/benchmark/tuners/__init__.py
+++ b/btb/benchmark/tuners/__init__.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from btb.benchmark.tuners.btb import make_btb_tuning_function
+from btb.benchmark.tuners.hyperopt import hyperopt_tuning_function
 from btb.tuning.tuners import GPEiTuner, GPTuner, UniformTuner
 
 
 def get_all_tuning_functions():
     """Return all the tuning functions ready to use with benchmark."""
     return {
-        'GPTuner()': make_btb_tuning_function(GPTuner),
-        'GPEiTuner()': make_btb_tuning_function(GPEiTuner),
-        'UniformTuner()': make_btb_tuning_function(UniformTuner),
+        'GPTuner': make_btb_tuning_function(GPTuner),
+        'GPEiTuner': make_btb_tuning_function(GPEiTuner),
+        'UniformTuner': make_btb_tuning_function(UniformTuner),
+        'HyperOpt': hyperopt_tuning_function,
     }

--- a/btb/benchmark/tuners/__init__.py
+++ b/btb/benchmark/tuners/__init__.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 
+from hyperopt import rand, tpe
+
 from btb.benchmark.tuners.btb import make_btb_tuning_function
-from btb.benchmark.tuners.hyperopt import hyperopt_tuning_function
+from btb.benchmark.tuners.hyperopt import make_hyperopt_tuning_function
 from btb.tuning.tuners import GPEiTuner, GPTuner, UniformTuner
 
 
 def get_all_tuning_functions():
     """Return all the tuning functions ready to use with benchmark."""
     return {
-        'GPTuner': make_btb_tuning_function(GPTuner),
-        'GPEiTuner': make_btb_tuning_function(GPEiTuner),
-        'UniformTuner': make_btb_tuning_function(UniformTuner),
-        'HyperOpt': hyperopt_tuning_function,
+        'BTB.GPTuner': make_btb_tuning_function(GPTuner),
+        'BTB.GPEiTuner': make_btb_tuning_function(GPEiTuner),
+        'BTB.UniformTuner': make_btb_tuning_function(UniformTuner),
+        'HyperOpt.tpe.suggest': make_hyperopt_tuning_function(tpe.suggest),
+        'HyperOpt.rand.suggest': make_hyperopt_tuning_function(rand.suggest),
     }

--- a/btb/benchmark/tuners/hyperopt.py
+++ b/btb/benchmark/tuners/hyperopt.py
@@ -1,0 +1,57 @@
+from hyperopt import Trials, fmin, hp, tpe
+
+
+def search_space_from_dict(dict_hyperparams):
+    hyperparams = {}
+
+    if not isinstance(dict_hyperparams, dict):
+        raise TypeError('Hyperparams must be a dictionary.')
+
+    for name, hyperparam in dict_hyperparams.items():
+        hp_type = hyperparam['type']
+
+        if hp_type == 'int':
+            hp_range = hyperparam.get('range') or hyperparam.get('values')
+            hp_min = min(hp_range) if hp_range else None
+            hp_max = max(hp_range) if hp_range else None
+            hp_instance = hp.uniformint(name, hp_min, hp_max)
+
+        elif hp_type == 'float':
+            hp_range = hyperparam.get('range') or hyperparam.get('values')
+            hp_min = min(hp_range)
+            hp_max = max(hp_range)
+            hp_instance = hp.uniform(name, hp_min, hp_max)
+
+        elif hp_type == 'bool':
+            hp_instance = hp.choice(name, [True, False])
+
+        elif hp_type == 'str':
+            hp_choices = hyperparam.get('range') or hyperparam.get('values')
+            hp_instance = hp.choice(name, hp_choices)
+
+        hyperparams[name] = hp_instance
+
+    return hyperparams
+
+
+def sanitize_scoring_function(scoring_function):
+    def sanitized(args):
+        return -scoring_function(**args)
+
+    return sanitized
+
+
+def hyperopt_tuning_function(scoring_function, tunable_hyperparameters, iterations):
+
+    # convert scoring to minimize
+    sanitized_scorer = sanitize_scoring_function(scoring_function)
+
+    search_space = search_space_from_dict(tunable_hyperparameters)
+    trials = Trials()
+
+    fmin(sanitized_scorer, search_space, algo=tpe.suggest, max_evals=iterations, trials=trials)
+
+    # normalize best score to match other tuners
+    best_score = -1 * trials.best_trial['result']['loss']
+
+    return best_score

--- a/btb/benchmark/tuners/hyperopt.py
+++ b/btb/benchmark/tuners/hyperopt.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from hyperopt import Trials, fmin, hp, tpe
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ tests_require = [
     'pytest-cov>=2.6.0',
     'hyperopt>=0.2.3,<3',
     'tabulate>=0.8.3,<0.9',
-    'dask>=2.12.0,<3',
+    'dask>=2.6.0,<3',
     'toolz>=0.10.0,<1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     extras_require={
         'examples': examples_require,
         'benchmark': benchmark_require,
-        'test': tests_require,
+        'test': tests_require + benchmark_require,
         'dev': development_requires + tests_require + benchmark_require,
     },
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,6 @@ install_requires = [
     'tqdm>=4.36.1,<4.50.0',
 ]
 
-benchmark_require = [
-    'hyperopt>=0.2.3,<3',
-    'tabulate>=0.8.3,<0.9',
-]
-
 
 examples_require = [
     'jupyter>=1.0.0',
@@ -47,6 +42,8 @@ examples_require = [
 tests_require = [
     'pytest>=3.4.2',
     'pytest-cov>=2.6.0',
+    'hyperopt>=0.2.3,<3',
+    'tabulate>=0.8.3,<0.9',
 ]
 
 
@@ -102,9 +99,8 @@ setup(
     description='Bayesian Tuning and Bandits',
     extras_require={
         'examples': examples_require,
-        'benchmark': benchmark_require,
-        'test': tests_require + benchmark_require,
-        'dev': development_requires + tests_require + benchmark_require,
+        'test': tests_require,
+        'dev': development_requires + tests_require,
     },
     include_package_data=True,
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         'examples': examples_require,
         'benchmark': benchmark_require,
         'test': tests_require,
-        'dev': development_requires + tests_require,
+        'dev': development_requires + tests_require + benchmark_require,
     },
     include_package_data=True,
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ except IOError:
 
 
 install_requires = [
-    'tabulate>=0.8.3,<0.9',
     'docutils>=0.10,<0.16',
     'boto3>=1.9.18,<1.10',
     'numpy>=1.14.0,<1.18.0',
@@ -31,6 +30,11 @@ install_requires = [
     'scipy>=1.0.1,<1.4.0',
     'pandas>=0.21.0,<0.26.0',
     'tqdm>=4.36.1,<4.50.0',
+]
+
+benchmark_require = [
+    'hyperopt>=0.2.3,<3',
+    'tabulate>=0.8.3,<0.9',
 ]
 
 
@@ -98,6 +102,7 @@ setup(
     description='Bayesian Tuning and Bandits',
     extras_require={
         'examples': examples_require,
+        'benchmark': benchmark_require,
         'test': tests_require,
         'dev': development_requires + tests_require,
     },

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ tests_require = [
     'pytest-cov>=2.6.0',
     'hyperopt>=0.2.3,<3',
     'tabulate>=0.8.3,<0.9',
+    'dask>=2.12.0,<3',
+    'toolz>=0.10.0,<1',
 ]
 
 

--- a/tests/benchmark/test___init__.py
+++ b/tests/benchmark/test___init__.py
@@ -5,37 +5,35 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
-from btb.benchmark import benchmark, evaluate_candidate
+from btb.benchmark import benchmark
 
 
 class TestBenchmark(TestCase):
 
-    def test_evaluate_candidate_challenge_is_instance(self):
-        # setup
-        candidate = MagicMock()
-        challenge = MagicMock()
-        challenge.__str__.return_value = 'test_challenge'
+    # def test__evaluate_candidate_challenge_is_instance(self):
+    #     # setup
+    #     candidate = MagicMock()
+    #     challenge = MagicMock()
+    #     challenge.__str__.return_value = 'test_challenge'
 
-        # run
-        result = evaluate_candidate('test_candidate', candidate, challenge, 10)
+    #     # run
+    #     result = _evaluate_candidate('test_candidate', candidate, challenge, 10)
 
-        # assert
-        challenge.get_tunable_hyperparameters.assert_called_once_with()
-        candidate.assert_called_once_with(
-            challenge.evaluate,
-            challenge.get_tunable_hyperparameters.return_value,
-            10
-        )
+    #     # assert
+    #     challenge.get_tunable_hyperparameters.assert_called_once_with()
+    #     candidate.assert_called_once_with(
+    #         challenge.evaluate,
+    #         challenge.get_tunable_hyperparameters.return_value,
+    #         10
+    #     )
 
-        expected_result = [
-            {
-                'challenge': 'test_challenge',
-                'candidate': 'test_candidate',
-                'score': candidate.return_value
-            }
-        ]
+    #     expected_result = {
+    #         'challenge': 'test_challenge',
+    #         'candidate': 'test_candidate',
+    #         'score': candidate.return_value
+    #     }
 
-        assert result == expected_result
+    #     assert result == expected_result
 
     @patch('btb.benchmark.evaluate_candidate')
     def test_benchmark_challenges_callable(self, mock_evaluate_candidate):
@@ -54,10 +52,10 @@ class TestBenchmark(TestCase):
 
         # assert
         expected_result = pd.DataFrame({
-            'test_challenge': [1.0],
+            'test_candidate': [1.0],
         })
 
-        expected_result.index = ['test_candidate']
+        expected_result.index = ['test_challenge']
 
         mock_evaluate_candidate.assert_called_once_with(
             'test_candidate',
@@ -89,10 +87,11 @@ class TestBenchmark(TestCase):
 
         # assert
         expected_result = pd.DataFrame({
-            'test_challenge': [1.0, 1.0],
+            'candidate_a': [1.0],
+            'candidate_b': [1.0],
         })
 
-        expected_result.index = ['candidate_a', 'candidate_b']
+        expected_result.index = ['test_challenge']
 
         pd.testing.assert_frame_equal(
             result.sort_index(axis=1),

--- a/tests/benchmark/tuners/test_hyperopt.py
+++ b/tests/benchmark/tuners/test_hyperopt.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import call, patch
+
+import pytest
+from hyperopt import tpe
+
+from btb.benchmark.tuners.hyperopt import (
+    hyperopt_tuning_function, sanitize_scoring_function, search_space_from_dict)
+
+
+def test_search_space_from_dict_not_dict():
+    """Test case for method."""
+    # setup
+    hyperparams = list()
+
+    # run
+    with pytest.raises(TypeError):
+        search_space_from_dict(hyperparams)
+
+
+@patch('btb.benchmark.tuners.hyperopt.hp')
+def test_search_space_from_dict(mock_hyperopt_hp):
+    # setup
+    mock_hyperopt_hp.uniform.return_value = 'float_hyperparam'
+    mock_hyperopt_hp.uniformint.return_value = 'int_hyperparam'
+    mock_hyperopt_hp.choice.side_effect = ['choice_hyperparam', 'bool_hyperparam']
+
+    dict_hyperparams = {
+        'int': {
+            'type': 'int',
+            'range': [1, 2],
+        },
+        'float': {
+            'type': 'float',
+            'range': [0, 1],
+        },
+        'cat': {
+            'type': 'str',
+            'range': ['a', 'b'],
+        },
+        'bool': {
+            'type': 'bool',
+        },
+    }
+
+    # run
+    res = search_space_from_dict(dict_hyperparams)
+
+    # assert
+    expected_res = {
+        'int': 'int_hyperparam',
+        'float': 'float_hyperparam',
+        'cat': 'choice_hyperparam',
+        'bool': 'bool_hyperparam',
+    }
+
+    expected_call_choice = [call('cat', ['a', 'b']), call('bool', [True, False])]
+    assert res == expected_res
+
+    mock_hyperopt_hp.uniformint.assert_called_once_with('int', 1, 2)
+    mock_hyperopt_hp.uniform.assert_called_once_with('float', 0, 1)
+    assert mock_hyperopt_hp.choice.call_args_list == expected_call_choice
+
+
+def test_sanitize_scoring_function():
+    # setup
+    def scoring_function(a):
+        return a
+
+    # run
+    res_func = sanitize_scoring_function(scoring_function)
+    result = res_func({'a': 1})
+
+    # assert
+    result == -1
+
+
+@patch('btb.benchmark.tuners.hyperopt.fmin')
+@patch('btb.benchmark.tuners.hyperopt.Trials')
+@patch('btb.benchmark.tuners.hyperopt.search_space_from_dict')
+@patch('btb.benchmark.tuners.hyperopt.sanitize_scoring_function')
+def test_hyperopt_tuning_function(mock_sanitize, mock_ss_from_dict, mock_trials, mock_fmin):
+    # setup
+    mock_sanitize.return_value = 'sanitized'
+    mock_ss_from_dict.return_value = 'search_space'
+    mock_trials.return_value.best_trial = {'result': {'loss': -1}}
+
+    # run
+    result = hyperopt_tuning_function('test_scoring_func', 'tunable_hps', 10)
+
+    # assert
+    assert result == 1
+
+    mock_sanitize.assert_called_once_with('test_scoring_func')
+    mock_ss_from_dict.assert_called_once_with('tunable_hps')
+    mock_trials.assert_called_once_with()
+
+    mock_fmin.assert_called_once_with(
+        'sanitized',
+        'search_space',
+        algo=tpe.suggest,
+        max_evals=10,
+        trials=mock_trials.return_value
+    )

--- a/tests/benchmark/tuners/test_hyperopt.py
+++ b/tests/benchmark/tuners/test_hyperopt.py
@@ -3,10 +3,8 @@
 from unittest.mock import call, patch
 
 import pytest
-from hyperopt import tpe
 
-from btb.benchmark.tuners.hyperopt import (
-    hyperopt_tuning_function, sanitize_scoring_function, search_space_from_dict)
+from btb.benchmark.tuners.hyperopt import make_minimize_function, search_space_from_dict
 
 
 def test_search_space_from_dict_not_dict():
@@ -24,9 +22,9 @@ def test_search_space_from_dict(mock_hyperopt_hp):
     # setup
     mock_hyperopt_hp.uniform.return_value = 'float_hyperparam'
     mock_hyperopt_hp.uniformint.return_value = 'int_hyperparam'
-    mock_hyperopt_hp.choice.side_effect = ['choice_hyperparam', 'bool_hyperparam']
+    mock_hyperopt_hp.choice.side_effect = ('choice_hyperparam', 'bool_hyperparam')
 
-    dict_hyperparams = {
+    dict_hyperparams_cat = {
         'int': {
             'type': 'int',
             'range': [1, 2],
@@ -38,68 +36,47 @@ def test_search_space_from_dict(mock_hyperopt_hp):
         'cat': {
             'type': 'str',
             'range': ['a', 'b'],
-        },
+        }
+    }
+
+    dict_hyperparams_bool = {
         'bool': {
             'type': 'bool',
-        },
+        }
     }
 
     # run
-    res = search_space_from_dict(dict_hyperparams)
+    res_cat = search_space_from_dict(dict_hyperparams_cat)
+    res_bool = search_space_from_dict(dict_hyperparams_bool)
 
     # assert
-    expected_res = {
+    expected_res_cat = {
         'int': 'int_hyperparam',
         'float': 'float_hyperparam',
         'cat': 'choice_hyperparam',
+    }
+    expected_res_bool = {
         'bool': 'bool_hyperparam',
     }
 
     expected_call_choice = [call('cat', ['a', 'b']), call('bool', [True, False])]
-    assert res == expected_res
+
+    assert res_cat == expected_res_cat
+    assert res_bool == expected_res_bool
 
     mock_hyperopt_hp.uniformint.assert_called_once_with('int', 1, 2)
     mock_hyperopt_hp.uniform.assert_called_once_with('float', 0, 1)
     assert mock_hyperopt_hp.choice.call_args_list == expected_call_choice
 
 
-def test_sanitize_scoring_function():
+def test_make_minimize_function():
     # setup
     def scoring_function(a):
         return a
 
     # run
-    res_func = sanitize_scoring_function(scoring_function)
+    res_func = make_minimize_function(scoring_function)
     result = res_func({'a': 1})
 
     # assert
     result == -1
-
-
-@patch('btb.benchmark.tuners.hyperopt.fmin')
-@patch('btb.benchmark.tuners.hyperopt.Trials')
-@patch('btb.benchmark.tuners.hyperopt.search_space_from_dict')
-@patch('btb.benchmark.tuners.hyperopt.sanitize_scoring_function')
-def test_hyperopt_tuning_function(mock_sanitize, mock_ss_from_dict, mock_trials, mock_fmin):
-    # setup
-    mock_sanitize.return_value = 'sanitized'
-    mock_ss_from_dict.return_value = 'search_space'
-    mock_trials.return_value.best_trial = {'result': {'loss': -1}}
-
-    # run
-    result = hyperopt_tuning_function('test_scoring_func', 'tunable_hps', 10)
-
-    # assert
-    assert result == 1
-
-    mock_sanitize.assert_called_once_with('test_scoring_func')
-    mock_ss_from_dict.assert_called_once_with('tunable_hps')
-    mock_trials.assert_called_once_with()
-
-    mock_fmin.assert_called_once_with(
-        'sanitized',
-        'search_space',
-        algo=tpe.suggest,
-        max_evals=10,
-        trials=mock_trials.return_value
-    )

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -13,6 +13,6 @@ def test_benchmark_rosenbrock():
     df = benchmark(candidate, challenges=Rosenbrock(), iterations=1)
 
     # Assert
-    np.testing.assert_equal(df.columns.values, ['Rosenbrock()'])
-    np.testing.assert_equal(df.index.values, ['tuning_function'])
+    np.testing.assert_equal(df.columns.values, ['tuning_function'])
+    np.testing.assert_equal(df.index.values, ['Rosenbrock()'])
     np.testing.assert_equal(df.dtypes.values, [np.int])

--- a/tests/run_benchmark.py
+++ b/tests/run_benchmark.py
@@ -6,16 +6,60 @@ from datetime import datetime
 
 import tabulate
 
-from btb.benchmark import DEFAULT_CHALLENGES, ATMChallenge, benchmark, get_all_tuning_functions
+from btb.benchmark import DEFAULT_CHALLENGES, benchmark
+from btb.benchmark.challenges import ATMChallenge
+from btb.benchmark.tuners import get_all_tuning_functions
 
 LOGGER = logging.getLogger(__name__)
 
 warnings.filterwarnings("ignore")
 
 
+def _get_candidates(args):
+    all_tuning_functions = get_all_tuning_functions()
+
+    if args.tuners is None:
+        LOGGER.info('Using all tuning functions.')
+
+        return all_tuning_functions
+
+    else:
+        selected_tuning_functions = {}
+
+        for name in args.tuners:
+            tuning_function = all_tuning_functions.get(name)
+
+            if tuning_function:
+                LOGGER.info('Loading tuning function: %s', name)
+                selected_tuning_functions[name] = tuning_function
+
+            else:
+                LOGGER.info('Could not load tuning function: %s', name)
+
+        if not selected_tuning_functions:
+            raise ValueError('No tunable function was loaded.')
+
+        return selected_tuning_functions
+
+
+def _update_challenges(challenges):
+    """Update the ``challenges`` list with the challenge class.
+
+    If a given challenge name is represented in ``DEFAULT_CHALLENGES``, replace it with
+    the given class so it's not used by ``ATMChallenge``.
+    """
+    for challenge in DEFAULT_CHALLENGES:
+        name = challenge.__name__
+        if name in challenges:
+            challenges[challenges.index(name)] = challenge
+
+    return challenges
+
+
 def _get_challenges(args):
     if args.challenges:
-        challenges = args.challenges
+        challenges = _update_challenges(args.challenges)
+
     else:
         challenges = ATMChallenge.get_available_datasets() + DEFAULT_CHALLENGES
 
@@ -33,7 +77,7 @@ def _get_challenges(args):
 
 
 def perform_benchmark(args):
-    candidates = get_all_tuning_functions()
+    candidates = _get_candidates(args)
     challenges = list(_get_challenges(args))
     results = benchmark(candidates, challenges, args.iterations)
 
@@ -52,7 +96,6 @@ def perform_benchmark(args):
 
 
 def _get_parser():
-    # Parser
     parser = argparse.ArgumentParser(description='BTB Benchmark Command Line Interface')
 
     parser.add_argument('-v', '--verbose', action='count', default=0,
@@ -63,7 +106,8 @@ def _get_parser():
                         help='Limit the test to a sample of datasets for the given size.')
     parser.add_argument('-i', '--iterations', type=int, default=100,
                         help='Number of iterations to perform per challenge with each candidate.')
-    parser.add_argument('challenges', nargs='*', help='Name of the challenge/s to be processed.')
+    parser.add_argument('--challenges', nargs='+', help='Name of the challenge/s to be processed.')
+    parser.add_argument('--tuners', nargs='+', help='Name of the tunables to be used.')
 
     return parser
 


### PR DESCRIPTION
- Resolve #184 
- Implemented `dask` for `benchmark`.
- Updated `run_benchmark` script to accept as input `btb.benchmark.challenges` as input and `btb.benchmark.tuners` tunables in order to run targeted benchmarks.