### PR TITLE
Issue 184 integrate benchmark with dask

### DIFF
--- a/btb/benchmark/__init__.py
+++ b/btb/benchmark/__init__.py
@@ -37,9 +37,6 @@ def _evaluate_candidate(name, candidate, challenge, iterations):
 
 
 def evaluate_candidate(name, candidate, challenges, iterations):
-    if not isinstance(challenges, list):
-        challenges = [challenges]
-
     candidate_results = []
     for challenge in challenges:
         try:
@@ -93,20 +90,16 @@ def benchmark(candidates, challenges=None, iterations=1000):
             returned.
     """
     if challenges is None:
-        challenges = [challenge_class() for challenge_class in DEFAULT_CHALLENGES]
+        challenges = DEFAULT_CHALLENGES
+    elif not isinstance(challenges, list):
+        challenges = [challenges]
 
     if callable(candidates):
         candidates = {candidates.__name__: candidates}
-
     elif isinstance(candidates, (list, tuple)):
         candidates = {candidate.__name__: candidate for candidate in candidates}
-
     elif not isinstance(candidates, dict):
-        raise TypeError(
-            'Candidates can only be a callable, list of callables, tuple of callables or dict.')
-
-    if not isinstance(challenges, list):
-        challenges = [challenges]
+        raise TypeError('Candidates can only be a callable, list or dict.')
 
     results = []
 

--- a/btb/benchmark/__init__.py
+++ b/btb/benchmark/__init__.py
@@ -43,14 +43,11 @@ def evaluate_candidate(name, candidate, challenges, iterations):
             if inspect.isclass(challenge):
                 challenge = challenge()
 
+            result = _evaluate_candidate(name, candidate, challenge, iterations)
+
         except Exception as ex:
             LOGGER.warn(
                 'Could not score candidate %s with challenge %s, error: %s', name, challenge, ex)
-            result = {
-                'challenge': str(challenge),
-                'candidate': name,
-                'score': None,
-            }
 
         candidate_results.append(result)
 

--- a/btb/benchmark/__init__.py
+++ b/btb/benchmark/__init__.py
@@ -37,22 +37,24 @@ def _evaluate_candidate(name, candidate, challenge, iterations):
 
 
 def evaluate_candidate(name, candidate, challenges, iterations):
-    candidate_result = []
-
     if not isinstance(challenges, list):
         challenges = [challenges]
 
+    candidate_results = []
     for challenge in challenges:
-        if inspect.isclass(challenge):
-            try:
+        try:
+            if inspect.isclass(challenge):
                 challenge = challenge()
-            except Exception as ex:
-                LOGGER.warn('Could not instantiate candidate %s', name, str(challenge), ex)
-                next
 
-        candidate_result.append(_evaluate_candidate(name, candidate, challenge, iterations))
+            result = _evaluate_candidate(name, candidate, challenge, iterations)
+            candidate_results.append(result)
 
-    return candidate_result
+        except Exception as ex:
+            LOGGER.warn('Could not evaluate candidate %s on challenge %s: %s',
+                        name, str(challenge), ex)
+            continue
+
+    return candidate_results
 
 
 def benchmark(candidates, challenges=None, iterations=1000):

--- a/btb/benchmark/tuners/__init__.py
+++ b/btb/benchmark/tuners/__init__.py
@@ -7,7 +7,7 @@ from btb.tuning.tuners import GPEiTuner, GPTuner, UniformTuner
 def get_all_tuning_functions():
     """Return all the tuning functions ready to use with benchmark."""
     return {
-        'GPTuner()': make_btb_tuning_function(GPTuner),
-        'GPEiTuner()': make_btb_tuning_function(GPEiTuner),
-        'UniformTuner()': make_btb_tuning_function(UniformTuner),
+        'GPTuner': make_btb_tuning_function(GPTuner),
+        'GPEiTuner': make_btb_tuning_function(GPEiTuner),
+        'UniformTuner': make_btb_tuning_function(UniformTuner),
     }

--- a/btb/benchmark/tuners/hyperopt.py
+++ b/btb/benchmark/tuners/hyperopt.py
@@ -66,7 +66,14 @@ def make_hyperopt_tuning_function(algo):
         minimized_scoring = make_minimize_function(scoring_function)
         search_space = search_space_from_dict(tunable_hyperparameters)
         trials = Trials()
-        fmin(minimized_scoring, search_space, algo=algo, max_evals=iterations, trials=trials)
+        fmin(
+            minimized_scoring,
+            search_space,
+            algo=algo,
+            max_evals=iterations,
+            trials=trials,
+            verbose=False
+        )
 
         # normalize best score to match other tuners
         best_score = -1 * trials.best_trial['result']['loss']

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ examples_require = [
 tests_require = [
     'pytest>=3.4.2',
     'pytest-cov>=2.6.0',
+    'dask>=2.6.0,<3',
+    'toolz>=0.10.0,<1',
 ]
 
 

--- a/tests/benchmark/test___init__.py
+++ b/tests/benchmark/test___init__.py
@@ -10,31 +10,6 @@ from btb.benchmark import benchmark
 
 class TestBenchmark(TestCase):
 
-    # def test__evaluate_candidate_challenge_is_instance(self):
-    #     # setup
-    #     candidate = MagicMock()
-    #     challenge = MagicMock()
-    #     challenge.__str__.return_value = 'test_challenge'
-
-    #     # run
-    #     result = _evaluate_candidate('test_candidate', candidate, challenge, 10)
-
-    #     # assert
-    #     challenge.get_tunable_hyperparameters.assert_called_once_with()
-    #     candidate.assert_called_once_with(
-    #         challenge.evaluate,
-    #         challenge.get_tunable_hyperparameters.return_value,
-    #         10
-    #     )
-
-    #     expected_result = {
-    #         'challenge': 'test_challenge',
-    #         'candidate': 'test_candidate',
-    #         'score': candidate.return_value
-    #     }
-
-    #     assert result == expected_result
-
     @patch('btb.benchmark.evaluate_candidate')
     def test_benchmark_challenges_callable(self, mock_evaluate_candidate):
         # setup

--- a/tests/benchmark/test___init__.py
+++ b/tests/benchmark/test___init__.py
@@ -5,37 +5,35 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
-from btb.benchmark import benchmark, evaluate_candidate
+from btb.benchmark import benchmark
 
 
 class TestBenchmark(TestCase):
 
-    def test_evaluate_candidate_challenge_is_instance(self):
-        # setup
-        candidate = MagicMock()
-        challenge = MagicMock()
-        challenge.__str__.return_value = 'test_challenge'
+    # def test__evaluate_candidate_challenge_is_instance(self):
+    #     # setup
+    #     candidate = MagicMock()
+    #     challenge = MagicMock()
+    #     challenge.__str__.return_value = 'test_challenge'
 
-        # run
-        result = evaluate_candidate('test_candidate', candidate, challenge, 10)
+    #     # run
+    #     result = _evaluate_candidate('test_candidate', candidate, challenge, 10)
 
-        # assert
-        challenge.get_tunable_hyperparameters.assert_called_once_with()
-        candidate.assert_called_once_with(
-            challenge.evaluate,
-            challenge.get_tunable_hyperparameters.return_value,
-            10
-        )
+    #     # assert
+    #     challenge.get_tunable_hyperparameters.assert_called_once_with()
+    #     candidate.assert_called_once_with(
+    #         challenge.evaluate,
+    #         challenge.get_tunable_hyperparameters.return_value,
+    #         10
+    #     )
 
-        expected_result = [
-            {
-                'challenge': 'test_challenge',
-                'candidate': 'test_candidate',
-                'score': candidate.return_value
-            }
-        ]
+    #     expected_result = {
+    #         'challenge': 'test_challenge',
+    #         'candidate': 'test_candidate',
+    #         'score': candidate.return_value
+    #     }
 
-        assert result == expected_result
+    #     assert result == expected_result
 
     @patch('btb.benchmark.evaluate_candidate')
     def test_benchmark_challenges_callable(self, mock_evaluate_candidate):
@@ -54,10 +52,10 @@ class TestBenchmark(TestCase):
 
         # assert
         expected_result = pd.DataFrame({
-            'test_challenge': [1.0],
+            'test_candidate': [1.0],
         })
 
-        expected_result.index = ['test_candidate']
+        expected_result.index = ['test_challenge']
 
         mock_evaluate_candidate.assert_called_once_with(
             'test_candidate',
@@ -89,10 +87,11 @@ class TestBenchmark(TestCase):
 
         # assert
         expected_result = pd.DataFrame({
-            'test_challenge': [1.0, 1.0],
+            'candidate_a': [1.0],
+            'candidate_b': [1.0],
         })
 
-        expected_result.index = ['candidate_a', 'candidate_b']
+        expected_result.index = ['test_challenge']
 
         pd.testing.assert_frame_equal(
             result.sort_index(axis=1),

--- a/tests/integration/test_benchmark.py
+++ b/tests/integration/test_benchmark.py
@@ -13,6 +13,6 @@ def test_benchmark_rosenbrock():
     df = benchmark(candidate, challenges=Rosenbrock(), iterations=1)
 
     # Assert
-    np.testing.assert_equal(df.columns.values, ['Rosenbrock()'])
-    np.testing.assert_equal(df.index.values, ['tuning_function'])
+    np.testing.assert_equal(df.columns.values, ['tuning_function'])
+    np.testing.assert_equal(df.index.values, ['Rosenbrock()'])
     np.testing.assert_equal(df.dtypes.values, [np.int])


### PR DESCRIPTION
- Resolve #184 
- Integrated dask for multiprocessing
- Updated `run_benchmark` script to accept as input `btb.benchmark.challenges` as input and `btb.benchmark.tuners` tunables in order to run targeted benchmarks.